### PR TITLE
Improve Document and File structs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.ci]
+fail-fast = false
+retries = 3

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install nextest
-        run: cargo install cargo-nextest
+        uses: taiki-e/install-action@nextest
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: nextest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ ariadne = "0.5.1"
 fastrace = "0.7.9"
 walkdir = "2.5.0"
 rayon-par-bridge = "0.1.0"
+bon = "3.6.4"
 
 [dependencies]
 tree-sitter-language = "0.1.5"

--- a/crates/codegen/src/utils.rs
+++ b/crates/codegen/src/utils.rs
@@ -219,6 +219,16 @@ pub static RUST_KEYWORDS: phf::Map<&'static str, &'static str> = phf::phf_map! {
     "Result" => "_Result",
     "Option" => "_Option",
     "Vec" => "_Vec",
+    "0" => "Zero",
+    "1" => "One",
+    "2" => "Two",
+    "3" => "Three",
+    "4" => "Four",
+    "5" => "Five",
+    "6" => "Six",
+    "7" => "Seven",
+    "8" => "Eight",
+    "9" => "Nine",
 };
 
 #[cfg(test)]
@@ -276,5 +286,9 @@ mod tests {
         assert_eq!(sanitize_string_to_pascal("hello_World"), "HelloWorld");
         // Test with multiple underscores
         assert_eq!(sanitize_string_to_pascal("hello__world"), "HelloWorld");
+
+        // Test numbers
+        assert_eq!(sanitize_string("0"), "Zero");
+        assert_eq!(sanitize_string("123"), "OneTwoThree");
     }
 }

--- a/crates/core/src/ast/node.rs
+++ b/crates/core/src/ast/node.rs
@@ -17,7 +17,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
 use crate::errors::PositionError;
+use crate::span::Span;
 use downcast_rs::{impl_downcast, DowncastSync};
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::sync::Arc;
 use tree_sitter::Node;
@@ -76,6 +78,11 @@ pub trait AstNode: std::fmt::Debug + Send + Sync + DowncastSync {
             line: range.end_point.row as u32,
             character: range.end_point.column as u32,
         }
+    }
+
+    /// Returns the range of this node as a [`Span`].
+    fn get_span(&self) -> Span<'_> {
+        Span(Cow::Borrowed(self.get_range()))
     }
 
     /// Returns the UTF-8 text slice corresponding to this node.

--- a/crates/core/src/ast/node.rs
+++ b/crates/core/src/ast/node.rs
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 use crate::errors::PositionError;
 use crate::span::Span;
 use downcast_rs::{impl_downcast, DowncastSync};
-use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::sync::Arc;
 use tree_sitter::Node;
@@ -81,8 +80,8 @@ pub trait AstNode: std::fmt::Debug + Send + Sync + DowncastSync {
     }
 
     /// Returns the range of this node as a [`Span`].
-    fn get_span(&self) -> Span<'_> {
-        Span(Cow::Borrowed(self.get_range()))
+    fn get_span(&self) -> Span {
+        Span(*self.get_range())
     }
 
     /// Returns the UTF-8 text slice corresponding to this node.

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -34,13 +34,13 @@ use thiserror::Error;
 pub enum ParseError {
     #[error("{error}")]
     LexerError {
-        span: Span<'static>,
+        span: Span,
         #[source]
         error: LexerError,
     },
     #[error("{error}")]
     AstError {
-        span: Span<'static>,
+        span: Span,
         #[source]
         error: AstError,
     },

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 use std::{collections::HashMap, path::PathBuf, str::Utf8Error};
 
+use crate::span::Span;
 use ariadne::{ColorGenerator, Fmt, Label, ReportBuilder, Source};
 use lsp_types::Url;
 use thiserror::Error;
@@ -33,13 +34,13 @@ use thiserror::Error;
 pub enum ParseError {
     #[error("{error}")]
     LexerError {
-        range: lsp_types::Range,
+        span: Span<'static>,
         #[source]
         error: LexerError,
     },
     #[error("{error}")]
     AstError {
-        range: lsp_types::Range,
+        span: Span<'static>,
         #[source]
         error: AstError,
     },
@@ -54,11 +55,11 @@ impl From<ParseError> for lsp_types::Diagnostic {
 impl From<&ParseError> for lsp_types::Diagnostic {
     fn from(error: &ParseError) -> Self {
         let (range, message) = match error {
-            ParseError::AstError { range, error } => (*range, error.to_string()),
-            ParseError::LexerError { range, error } => (*range, error.to_string()),
+            ParseError::AstError { span: range, error } => (range, error.to_string()),
+            ParseError::LexerError { span: range, error } => (range, error.to_string()),
         };
         lsp_types::Diagnostic {
-            range,
+            range: range.into(),
             severity: Some(lsp_types::DiagnosticSeverity::ERROR),
             message,
             code: Some(lsp_types::NumberOrString::String("AUTO_LSP".into())),
@@ -76,8 +77,8 @@ impl ParseError {
         report: &mut ReportBuilder<'_, std::ops::Range<usize>>,
     ) {
         let range = match self {
-            ParseError::LexerError { range, .. } => range,
-            ParseError::AstError { range, .. } => range,
+            ParseError::LexerError { span: range, .. } => range.lsp(),
+            ParseError::AstError { span: range, .. } => range.lsp(),
         };
         let start_line = source.line(range.start.line as usize).unwrap().offset();
         let end_line = source.line(range.end.line as usize).unwrap().offset();
@@ -107,18 +108,12 @@ pub enum AstError {
 impl From<AstError> for ParseError {
     fn from(error: AstError) -> Self {
         let range = match &error {
-            AstError::UnexpectedSymbol { range, .. } => lsp_types::Range {
-                start: lsp_types::Position {
-                    line: range.start_point.row as u32,
-                    character: range.start_point.column as u32,
-                },
-                end: lsp_types::Position {
-                    line: range.end_point.row as u32,
-                    character: range.end_point.column as u32,
-                },
-            },
+            AstError::UnexpectedSymbol { range, .. } => *range,
         };
-        Self::AstError { range, error }
+        Self::AstError {
+            span: range.into(),
+            error,
+        }
     }
 }
 
@@ -129,14 +124,14 @@ impl From<AstError> for ParseError {
 pub enum LexerError {
     #[error("{error}")]
     Missing {
-        range: lsp_types::Range,
+        range: tree_sitter::Range,
         error: String,
         // Missing node's symbol name as it appears in the grammar ignoring aliases as a string
         grammar_name: &'static str,
     },
     #[error("{error}")]
     Syntax {
-        range: lsp_types::Range,
+        range: tree_sitter::Range,
         error: String,
         affected: String,
     },
@@ -148,7 +143,10 @@ impl From<LexerError> for ParseError {
             LexerError::Missing { range, .. } => *range,
             LexerError::Syntax { range, .. } => *range,
         };
-        Self::LexerError { range, error }
+        Self::LexerError {
+            span: range.into(),
+            error,
+        }
     }
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -33,4 +33,5 @@ pub mod document;
 pub mod errors;
 pub mod parsers;
 pub mod regex;
+pub mod span;
 pub mod utils;

--- a/crates/core/src/span.rs
+++ b/crates/core/src/span.rs
@@ -88,7 +88,6 @@ mod tests {
 
         let span = Span(range);
 
-        assert_eq!(span, range);
         assert_eq!(
             span,
             lsp_types::Range {

--- a/crates/core/src/span.rs
+++ b/crates/core/src/span.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, ops::Deref};
+use std::ops::Deref;
 
 /// A newtype for [`tree_sitter::Range`].
 ///
@@ -8,9 +8,9 @@ use std::{borrow::Cow, ops::Deref};
 ///
 /// Tree-sitter ranges also retain byte offsets, which are not available in [`lsp_types::Range`].
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Span<'a>(pub(crate) Cow<'a, tree_sitter::Range>);
+pub struct Span(pub(crate) tree_sitter::Range);
 
-impl<'a> Span<'a> {
+impl Span {
     pub fn lsp(&self) -> lsp_types::Range {
         self.into()
     }
@@ -20,7 +20,7 @@ impl<'a> Span<'a> {
     }
 }
 
-impl Deref for Span<'_> {
+impl Deref for Span {
     type Target = tree_sitter::Range;
 
     fn deref(&self) -> &Self::Target {
@@ -28,19 +28,19 @@ impl Deref for Span<'_> {
     }
 }
 
-impl<'a> From<tree_sitter::Range> for Span<'a> {
+impl From<tree_sitter::Range> for Span {
     fn from(range: tree_sitter::Range) -> Self {
-        Span(Cow::Owned(range))
+        Span(range)
     }
 }
 
-impl<'a> From<&'a tree_sitter::Range> for Span<'a> {
+impl<'a> From<&'a tree_sitter::Range> for Span {
     fn from(range: &'a tree_sitter::Range) -> Self {
-        Span(Cow::Borrowed(range))
+        Span(range.clone())
     }
 }
 
-impl From<&Span<'_>> for lsp_types::Range {
+impl From<&Span> for lsp_types::Range {
     fn from(range: &Span) -> Self {
         lsp_types::Range {
             start: lsp_types::Position::new(
@@ -55,19 +55,19 @@ impl From<&Span<'_>> for lsp_types::Range {
     }
 }
 
-impl From<Span<'_>> for lsp_types::Range {
+impl From<Span> for lsp_types::Range {
     fn from(span: Span) -> Self {
         (&span).into()
     }
 }
 
-impl PartialEq<tree_sitter::Range> for Span<'_> {
+impl PartialEq<tree_sitter::Range> for Span {
     fn eq(&self, other: &tree_sitter::Range) -> bool {
-        *self == Span(Cow::Borrowed(other))
+        self == other
     }
 }
 
-impl PartialEq<lsp_types::Range> for Span<'_> {
+impl PartialEq<lsp_types::Range> for Span {
     fn eq(&self, other: &lsp_types::Range) -> bool {
         lsp_types::Range::from(self) == *other
     }
@@ -86,7 +86,7 @@ mod tests {
             end_point: tree_sitter::Point::new(0, 10),
         };
 
-        let span = Span(Cow::Owned(range));
+        let span = Span(range);
 
         assert_eq!(span, range);
         assert_eq!(

--- a/crates/core/src/span.rs
+++ b/crates/core/src/span.rs
@@ -1,0 +1,100 @@
+use std::{borrow::Cow, ops::Deref};
+
+/// A newtype for [`tree_sitter::Range`].
+///
+/// Useful for storing and converting ranges from Tree-sitter to LSP types.
+///
+/// This is typically used when storing positions in an intermediate representation (IR) of the AST.
+///
+/// Tree-sitter ranges also retain byte offsets, which are not available in [`lsp_types::Range`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Span<'a>(pub(crate) Cow<'a, tree_sitter::Range>);
+
+impl<'a> Span<'a> {
+    pub fn lsp(&self) -> lsp_types::Range {
+        self.into()
+    }
+
+    pub fn ts(&self) -> &tree_sitter::Range {
+        &self.0
+    }
+}
+
+impl Deref for Span<'_> {
+    type Target = tree_sitter::Range;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> From<tree_sitter::Range> for Span<'a> {
+    fn from(range: tree_sitter::Range) -> Self {
+        Span(Cow::Owned(range))
+    }
+}
+
+impl<'a> From<&'a tree_sitter::Range> for Span<'a> {
+    fn from(range: &'a tree_sitter::Range) -> Self {
+        Span(Cow::Borrowed(range))
+    }
+}
+
+impl From<&Span<'_>> for lsp_types::Range {
+    fn from(range: &Span) -> Self {
+        lsp_types::Range {
+            start: lsp_types::Position::new(
+                range.0.start_point.row as u32,
+                range.0.start_point.column as u32,
+            ),
+            end: lsp_types::Position::new(
+                range.0.end_point.row as u32,
+                range.0.end_point.column as u32,
+            ),
+        }
+    }
+}
+
+impl From<Span<'_>> for lsp_types::Range {
+    fn from(span: Span) -> Self {
+        (&span).into()
+    }
+}
+
+impl PartialEq<tree_sitter::Range> for Span<'_> {
+    fn eq(&self, other: &tree_sitter::Range) -> bool {
+        *self == Span(Cow::Borrowed(other))
+    }
+}
+
+impl PartialEq<lsp_types::Range> for Span<'_> {
+    fn eq(&self, other: &lsp_types::Range) -> bool {
+        lsp_types::Range::from(self) == *other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn span_equality() {
+        let range = tree_sitter::Range {
+            start_byte: 0,
+            end_byte: 10,
+            start_point: tree_sitter::Point::new(10, 0),
+            end_point: tree_sitter::Point::new(0, 10),
+        };
+
+        let span = Span(Cow::Owned(range));
+
+        assert_eq!(span, range);
+        assert_eq!(
+            span,
+            lsp_types::Range {
+                start: lsp_types::Position::new(10, 0),
+                end: lsp_types::Position::new(0, 10),
+            }
+        );
+    }
+}

--- a/crates/default/Cargo.toml
+++ b/crates/default/Cargo.toml
@@ -24,6 +24,7 @@ log = { workspace = true }
 fastrace = { workspace = true }
 rayon = { workspace = true }
 rayon-par-bridge = { workspace = true }
+bon = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.19.0"

--- a/crates/default/Cargo.toml
+++ b/crates/default/Cargo.toml
@@ -25,6 +25,7 @@ fastrace = { workspace = true }
 rayon = { workspace = true }
 rayon-par-bridge = { workspace = true }
 bon = { workspace = true }
+anyhow = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.19.0"

--- a/crates/default/src/db/file.rs
+++ b/crates/default/src/db/file.rs
@@ -1,0 +1,241 @@
+use std::{io::Read, path::Path, sync::Arc};
+
+use auto_lsp_core::{
+    document::Document,
+    errors::{DataBaseError, ExtensionError, FileSystemError, RuntimeError, TreeSitterError},
+    parsers::Parsers,
+};
+use auto_lsp_server::Session;
+use bon::bon;
+use lsp_types::{DidChangeTextDocumentParams, PositionEncodingKind, Url};
+use salsa::Setter;
+use texter::core::text::Text;
+use tree_sitter::Tree;
+
+use crate::{db::BaseDatabase, server::workspace_init::get_extension};
+
+/// A salsa input that represents a file in the database.
+///
+/// Multiple builders are provided to create a file:
+///  - `from_fs`: Creates a file by reading the file system.
+///  - `from_text_doc`: Creates a file from a text document event.
+///  - `from_string`: Creates a file from a string.
+///
+/// `from_fs` is suitable for file watchers and workspace loading (e.g. [`lsp_types::notification::DidChangeWatchedFiles`]).
+///
+/// `from_text_doc` is suitable for text document events (e.g. [`lsp_types::notification::DidChangeTextDocument`]).
+///
+/// `from_string` is suitable for tests and in-memory files.
+#[salsa::input]
+pub struct File {
+    #[return_ref]
+    pub url: Url,
+    pub parsers: &'static Parsers,
+    #[return_ref]
+    pub document: Arc<Document>,
+    // Document version, None if created via the file system.
+    pub version: Option<i32>,
+}
+
+#[bon]
+impl File {
+    /// Creates a new file by reading the file system.
+    #[builder]
+    pub fn from_fs(session: &Session<impl BaseDatabase>, url: &Url) -> Result<Self, RuntimeError> {
+        let file_path = url.to_file_path().map_err(|_| {
+            RuntimeError::from(FileSystemError::FileUrlToFilePath { path: url.clone() })
+        })?;
+
+        let (parsers, _, text) =
+            Self::read_file(session, &file_path).map_err(RuntimeError::from)?;
+
+        let tree = Self::ts_parse(parsers, &text, url)?;
+        let document = Document::new(text, tree, Some(&session.encoding));
+
+        Ok(File::new(
+            &session.db,
+            url.clone(),
+            parsers,
+            Arc::new(document),
+            None,
+        ))
+    }
+
+    /// Creates a new file from a text document event.
+    #[builder]
+    pub fn from_text_doc(
+        session: &Session<impl salsa::Database>,
+        doc: &lsp_types::TextDocumentItem,
+    ) -> Result<Self, RuntimeError> {
+        let url = &doc.uri;
+        let text = Text::new(doc.text.clone());
+
+        let parsers = Self::get_ast_parser(session, &doc.language_id)?;
+        let tree = Self::ts_parse(parsers, &text, url)?;
+        let document = Document::new(text, tree, Some(&session.encoding));
+
+        Ok(File::new(
+            &session.db,
+            url.clone(),
+            parsers,
+            Arc::new(document),
+            Some(doc.version),
+        ))
+    }
+
+    /// Creates a new file from a string.
+    #[builder]
+    pub fn from_string(
+        db: &impl salsa::Database,
+        source: String,
+        url: &Url,
+        parsers: &'static Parsers,
+        encoding: Option<&PositionEncodingKind>,
+    ) -> Result<Self, RuntimeError> {
+        let text = Text::new(source);
+
+        let tree = Self::ts_parse(parsers, &text, url)?;
+        let document = Document::new(text, tree, encoding);
+
+        Ok(File::new(
+            db,
+            url.clone(),
+            parsers,
+            Arc::new(document),
+            None,
+        ))
+    }
+
+    /// Updates the file from a [`DidChangeTextDocumentParams`] event.
+    pub fn update_edit(
+        &self,
+        db: &mut impl salsa::Database,
+        event: &DidChangeTextDocumentParams,
+    ) -> Result<(), DataBaseError> {
+        let changes = &event.content_changes;
+        let mut doc = (*self.document(db)).clone();
+
+        doc.update(&mut self.parsers(db).parser.write(), changes)
+            .map_err(|e| DataBaseError::from((&self.url(db), e)))?;
+
+        self.set_document(db).to(Arc::new(doc));
+        self.set_version(db).to(Some(event.text_document.version));
+        Ok(())
+    }
+
+    /// Updates the file from the file system.
+    pub fn update_full_fs(
+        &self,
+        session: &mut Session<impl BaseDatabase>,
+    ) -> Result<(), RuntimeError> {
+        let url = self.url(&session.db).clone();
+
+        let file_path = url.to_file_path().map_err(|_| {
+            RuntimeError::from(FileSystemError::FileUrlToFilePath { path: url.clone() })
+        })?;
+
+        let (parsers, _, text) =
+            Self::read_file(&session, &file_path).map_err(RuntimeError::from)?;
+
+        let tree = Self::ts_parse(parsers, &text, &url)?;
+        let document = Document::new(text, tree, Some(&session.encoding));
+
+        let db = &mut session.db;
+        self.set_document(db).to(Arc::new(document));
+        Ok(())
+    }
+
+    /// Updates the file from a full text document.
+    pub fn update_full_text_doc(
+        &self,
+        session: &mut Session<impl salsa::Database>,
+        event: &lsp_types::TextDocumentItem,
+    ) -> Result<(), DataBaseError> {
+        let db = &mut session.db;
+        let text = Text::new(event.text.clone());
+        let tree = Self::ts_parse(self.parsers(db), &text, &self.url(db))?;
+        let document = Document::new(text, tree, Some(&PositionEncodingKind::UTF16));
+
+        self.set_document(db).to(Arc::new(document));
+        self.set_version(db).to(Some(event.version));
+        Ok(())
+    }
+
+    /// Resets the file to an empty document.
+    pub fn reset(&self, db: &mut impl BaseDatabase) -> Result<(), DataBaseError> {
+        let text = Text::new("".into());
+        let tree = Self::ts_parse(self.parsers(db), &text, &self.url(db))?;
+        let document = Document::new(text, tree, Some(&PositionEncodingKind::UTF16));
+
+        self.set_document(db).to(Arc::new(document));
+        self.set_version(db).to(None);
+        Ok(())
+    }
+
+    pub fn read_file(
+        session: &Session<impl BaseDatabase>,
+        file: &Path,
+    ) -> Result<(&'static Parsers, Url, Text), RuntimeError> {
+        let url = Url::from_file_path(file).map_err(|_| FileSystemError::FilePathToUrl {
+            path: file.to_path_buf(),
+        })?;
+
+        let mut open_file = std::fs::File::open(file).map_err(|e| FileSystemError::FileOpen {
+            path: url.clone(),
+            error: e.to_string(),
+        })?;
+        let mut buffer = String::new();
+        open_file
+            .read_to_string(&mut buffer)
+            .map_err(|e| FileSystemError::FileRead {
+                path: url.clone(),
+                error: e.to_string(),
+            })?;
+
+        let extension = get_extension(&url)?;
+
+        let parsers = Self::get_ast_parser(session, &extension)?;
+        let text = Text::new(buffer);
+
+        Ok((parsers, url, text))
+    }
+
+    /// Utility function to parse a tree sitter tree.
+    fn ts_parse(parsers: &'static Parsers, text: &Text, url: &Url) -> Result<Tree, DataBaseError> {
+        parsers
+            .parser
+            .write()
+            .parse(text.text.as_bytes(), None)
+            .ok_or_else(|| DataBaseError::from((url, TreeSitterError::TreeSitterParser)))
+    }
+
+    /// Utility function to get the AST parser for an extension.
+    fn get_ast_parser(
+        session: &Session<impl salsa::Database>,
+        extension: &str,
+    ) -> Result<&'static Parsers, RuntimeError> {
+        // Check if the extension is registered
+        let extension = match session.extensions.get(extension) {
+            Some(extension) => extension,
+            None => {
+                if session.extensions.values().any(|x| x == extension) {
+                    extension
+                } else {
+                    return Err(ExtensionError::UnknownExtension {
+                        extension: extension.to_string(),
+                        available: session.extensions.clone(),
+                    }
+                    .into());
+                }
+            }
+        };
+
+        // Check if the parser for this extension is available
+        session.init_options.parsers.get(extension).ok_or_else(|| {
+            RuntimeError::from(ExtensionError::UnknownParser {
+                extension: extension.to_string(),
+                available: session.init_options.parsers.keys().cloned().collect(),
+            })
+        })
+    }
+}

--- a/crates/default/src/db/lexer.rs
+++ b/crates/default/src/db/lexer.rs
@@ -17,7 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
 use auto_lsp_core::errors::{LexerError, ParseErrorAccumulator};
-use lsp_types::{Position, Range};
 use salsa::Accumulator;
 use tree_sitter::Node;
 
@@ -43,22 +42,9 @@ pub fn get_tree_sitter_errors(db: &dyn BaseDatabase, node: &Node, source_code: &
 }
 
 fn format_error(node: &Node, source_code: &[u8]) -> LexerError {
-    let start_position = node.start_position();
-    let end_position = node.end_position();
-    let range = Range {
-        start: Position {
-            line: start_position.row as u32,
-            character: start_position.column as u32,
-        },
-        end: Position {
-            line: end_position.row as u32,
-            character: end_position.column as u32,
-        },
-    };
-
     if node.is_missing() {
         LexerError::Missing {
-            range,
+            range: node.range(),
             error: format!("Syntax error: Missing '{}'", node.grammar_name()),
             grammar_name: node.grammar_name(),
         }
@@ -73,7 +59,7 @@ fn format_error(node: &Node, source_code: &[u8]) -> LexerError {
             })
             .collect();
         LexerError::Syntax {
-            range,
+            range: node.range(),
             error: format!("Unexpected token(s): '{}'", children_text.join(" ")),
             affected: children_text.join(" "),
         }

--- a/crates/default/src/db/mod.rs
+++ b/crates/default/src/db/mod.rs
@@ -85,7 +85,7 @@ impl BaseDatabase for BaseDb {
 /// This trait is implemented for any database that implements [`BaseDatabase`].
 pub trait FileManager: BaseDatabase + salsa::Database {
     fn add_file(&mut self, file: File) -> Result<(), DataBaseError> {
-        match self.get_files().entry(file.url(self)) {
+        match self.get_files().entry(file.url(self).clone()) {
             Entry::Occupied(_) => Err(DataBaseError::FileAlreadyExists {
                 uri: file.url(self).clone(),
             }),

--- a/crates/default/src/server/file_events.rs
+++ b/crates/default/src/server/file_events.rs
@@ -16,42 +16,66 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+use auto_lsp_core::errors::DataBaseError;
 use auto_lsp_core::errors::FileSystemError;
 use auto_lsp_core::errors::RuntimeError;
 use auto_lsp_server::Session;
+use lsp_types::DidChangeTextDocumentParams;
 use lsp_types::DidChangeWatchedFilesParams;
 use lsp_types::DidOpenTextDocumentParams;
 use lsp_types::FileChangeType;
+use salsa::Setter;
 
 use crate::db::BaseDatabase;
 use crate::db::{file::File, FileManager};
 
+/// Handles a [`DidOpenTextDocument`] request.
+///
+/// If the file already exists in the database, it updates its version.
+///
+/// If it does not exist, it creates a new file from the text document parameters.
 pub fn open_text_document<Db: BaseDatabase>(
     session: &mut Session<Db>,
     params: DidOpenTextDocumentParams,
 ) -> Result<(), RuntimeError> {
     let url = &params.text_document.uri;
 
-    if session.db.get_file(url).is_some() {
-        // The file is already in db
-        // We can ignore this change
-        return Ok(());
-    };
+    match session.db.get_file(url) {
+        Some(file) => {
+            log::info!("Did Open Text Document: Already exists - {url}");
+            file.set_version(&mut session.db)
+                .to(Some(params.text_document.version));
+            Ok(())
+        }
+        None => {
+            let file = File::from_text_doc()
+                .doc(&params.text_document)
+                .session(session)
+                .call()?;
 
-    let file = File::from_text_doc()
-        .doc(&params.text_document)
-        .session(session)
-        .call()?;
+            log::info!("Did Open Text Document: Created - {url}");
+            session.db.add_file(file).map_err(|e| e.into())
+        }
+    }
+}
 
-    log::info!("Did Open Text Document: Created - {url}");
-    session.db.add_file(file).map_err(|e| e.into())
+/// Handles a [`DidChangeTextDocument`] request.
+pub fn change_text_document<Db: BaseDatabase>(
+    session: &mut Session<Db>,
+    params: DidChangeTextDocumentParams,
+) -> Result<(), RuntimeError> {
+    let file = session
+        .db
+        .get_file(&params.text_document.uri)
+        .ok_or_else(|| DataBaseError::FileNotFound {
+            uri: params.text_document.uri.clone(),
+        })?;
+
+    log::info!("Did Change Text Document: {}", params.text_document.uri);
+    Ok(file.update_edit(&mut session.db, &params)?)
 }
 
 /// Handle the watched files change notification.
-///
-/// The differences between this and the document requests is that the watched files are not necessarily modified by the client.
-///
-/// Some changes can be made by external tools, github, someone editing the project with NotePad while the IDE is active, etc ...
 pub fn changed_watched_files<Db: BaseDatabase>(
     session: &mut Session<Db>,
     params: DidChangeWatchedFilesParams,
@@ -63,6 +87,11 @@ pub fn changed_watched_files<Db: BaseDatabase>(
         match file.typ {
             FileChangeType::CREATED => {
                 let url = &file.uri;
+                if session.db.get_file(url).is_some() {
+                    // The file is already in db
+                    // We can ignore this change
+                    return Ok(());
+                }
                 let file = File::from_fs().session(session).url(&url).call()?;
 
                 log::info!("Watched Files: Created - {url}");
@@ -79,12 +108,12 @@ pub fn changed_watched_files<Db: BaseDatabase>(
             }
             FileChangeType::DELETED => {
                 let url = &file.uri;
-                let file = session.db.get_file(&url).ok_or_else(|| {
-                    RuntimeError::from(FileSystemError::FileUrlToFilePath {
-                        path: file.uri.clone(),
-                    })
-                })?;
+                if session.db.get_file(&url).is_none() {
+                    // The file is not in db, we can ignore this change
+                    return Ok(());
+                }
 
+                let file = session.db.get_file(&url).unwrap();
                 file.reset(&mut session.db).map_err(RuntimeError::from)?;
 
                 log::info!("Watched Files: Deleted - {}", &url);

--- a/crates/default/src/server/file_events.rs
+++ b/crates/default/src/server/file_events.rs
@@ -75,7 +75,7 @@ pub fn open_text_document<Db: BaseDatabase>(
     log::info!("Did Open Text Document: Created - {url}");
     session
         .db
-        .add_file_from_texter(parsers, url, text)
+        .add_file_from_texter(parsers, url, &session.encoding, text)
         .map_err(|e| e.into())
 }
 
@@ -110,7 +110,7 @@ pub fn changed_watched_files<Db: BaseDatabase>(
                 log::info!("Watched Files: Created - {uri}");
                 session
                     .db
-                    .add_file_from_texter(parsers, &url, text)
+                    .add_file_from_texter(parsers, &url, &session.encoding, text)
                     .map_err(RuntimeError::from)
             }
             FileChangeType::CHANGED => {
@@ -145,7 +145,7 @@ pub fn changed_watched_files<Db: BaseDatabase>(
                                 session.read_file(&file_path).map_err(RuntimeError::from)?;
                             session
                                 .db
-                                .add_file_from_texter(parsers, &url, text)
+                                .add_file_from_texter(parsers, &url, &session.encoding, text)
                                 .map_err(RuntimeError::from)
                         } else {
                             // The file is already in db and the content is the same

--- a/crates/default/src/server/workspace_init.rs
+++ b/crates/default/src/server/workspace_init.rs
@@ -70,7 +70,7 @@ impl<Db: BaseDatabase> WorkspaceInit for Session<Db> {
                         .map(|file| match self.read_file(&file.into_path()) {
                             Ok((parsers, url, text)) => self
                                 .db
-                                .add_file_from_texter(parsers, &url, text)
+                                .add_file_from_texter(parsers, &url, &self.encoding, text)
                                 .map_err(RuntimeError::from),
                             Err(err) => Err(RuntimeError::from(err)),
                         })

--- a/crates/server/src/init.rs
+++ b/crates/server/src/init.rs
@@ -75,8 +75,17 @@ impl<Db: salsa::Database> Session<Db> {
 
         log::info!("Max threads: {max_threads}");
 
+        let encoding = init_options
+            .capabilities
+            .position_encoding
+            .clone()
+            .unwrap_or(PositionEncodingKind::UTF16);
+
+        log::info!("Position encoding: {encoding:?}");
+
         Self {
             init_options,
+            encoding,
             connection,
             text_fn,
             extensions: HashMap::new(),

--- a/crates/server/src/init.rs
+++ b/crates/server/src/init.rs
@@ -73,7 +73,7 @@ impl<Db: salsa::Database> Session<Db> {
     ///
     /// This will establish the connection with the client and send the server capabilities.
     pub fn create(
-        mut init_options: InitOptions,
+        init_options: InitOptions,
         connection: Connection,
         db: Db,
     ) -> anyhow::Result<(Session<Db>, InitializeParams)> {
@@ -89,12 +89,6 @@ impl<Db: salsa::Database> Session<Db> {
         // also be implemented to use sockets or HTTP.
         let (id, resp) = connection.initialize_start()?;
         let params: InitializeParams = serde_json::from_value(resp)?;
-
-        let pos_encoding = params
-            .capabilities
-            .general
-            .as_ref()
-            .and_then(|g| g.position_encodings.as_deref());
 
         let server_capabilities = serde_json::to_value(&InitializeResult {
             capabilities: init_options.capabilities.clone(),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-use init::TextFn;
 use lsp_server::Connection;
 use main_loop::Task;
 use options::InitOptions;
@@ -39,7 +38,6 @@ pub struct Session<Db: salsa::Database> {
     /// Text `fn` used to parse text files with the correct encoding.
     ///
     /// The client is responsible for providing the encoding at initialization (UTF-8, 16 or 32).
-    pub text_fn: TextFn,
     pub encoding: lsp_types::PositionEncodingKind,
     /// Language extensions to parser mappings.
     pub extensions: HashMap<String, String>,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -40,6 +40,7 @@ pub struct Session<Db: salsa::Database> {
     ///
     /// The client is responsible for providing the encoding at initialization (UTF-8, 16 or 32).
     pub text_fn: TextFn,
+    pub encoding: lsp_types::PositionEncodingKind,
     /// Language extensions to parser mappings.
     pub extensions: HashMap<String, String>,
     pub(crate) task_rx: crossbeam_channel::Receiver<Task>,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -42,7 +42,7 @@ pub struct Session<Db: salsa::Database> {
     /// Language extensions to parser mappings.
     pub extensions: HashMap<String, String>,
     pub(crate) task_rx: crossbeam_channel::Receiver<Task>,
-    pub(crate) task_pool: task_pool::TaskPool<Task>,
+    pub task_pool: task_pool::TaskPool<Task>,
     /// Request queue for incoming requests
     pub req_queue: ReqQueue<Db>,
     pub connection: Connection,

--- a/crates/server/src/main_loop.rs
+++ b/crates/server/src/main_loop.rs
@@ -26,7 +26,7 @@ use crossbeam_channel::select;
 use lsp_server::Message;
 
 #[derive(Debug)]
-pub(crate) enum Task {
+pub enum Task {
     Response(lsp_server::Response),
     NotificationError(Error),
 }

--- a/examples/ast-html/src/db.rs
+++ b/examples/ast-html/src/db.rs
@@ -16,10 +16,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 use crate::generated::Document;
-use auto_lsp::configure_parsers;
 use auto_lsp::default::db::{BaseDatabase, BaseDb, FileManager};
 use auto_lsp::lsp_types::Url;
 use auto_lsp::texter::core::text::Text;
+use auto_lsp::{configure_parsers, lsp_types};
 
 configure_parsers!(
     HTML_PARSERS,
@@ -37,6 +37,7 @@ pub fn create_html_db(source_code: &'static [&str]) -> impl BaseDatabase {
         db.add_file_from_texter(
             HTML_PARSERS.get("html").expect("Html parser not found"),
             &url,
+            &lsp_types::PositionEncodingKind::UTF8,
             Text::new(source_code.to_string()),
         )
         .expect("Failed to add file");

--- a/examples/ast-html/src/tests/files.rs
+++ b/examples/ast-html/src/tests/files.rs
@@ -1,0 +1,61 @@
+#[cfg(test)]
+mod tests {
+    use auto_lsp::{default::db::file::File, lsp_types::Url, salsa};
+
+    fn make_html_file(db: &impl salsa::Database, content: &str) -> File {
+        // Minimal fake setup: real code may require a salsa DB & parser
+        let url = Url::parse("file:///test.txt").unwrap();
+        File::from_string()
+            .db(db)
+            .maybe_encoding(None)
+            .source(content.to_string())
+            .url(&url)
+            .parsers(
+                crate::db::HTML_PARSERS
+                    .get("html")
+                    .expect("Html parser not found"),
+            )
+            .call()
+            .expect("Failed to create file")
+    }
+
+    #[test]
+    fn test_same_content() {
+        let db = salsa::DatabaseImpl::default();
+        let file = make_html_file(&db, "hello world");
+        assert!(file.fail_fast_check(&db, "hello world"));
+    }
+
+    #[test]
+    fn test_different_length() {
+        let db = salsa::DatabaseImpl::default();
+        let file = make_html_file(&db, "hello");
+        assert!(!file.fail_fast_check(&db, "hello world"));
+    }
+
+    #[test]
+    fn test_same_length_different_content() {
+        let db = salsa::DatabaseImpl::default();
+        let file = make_html_file(&db, "hello");
+        assert!(!file.fail_fast_check(&db, "hELlo"));
+    }
+
+    #[test]
+    fn test_large_equal_content() {
+        let db = salsa::DatabaseImpl::default();
+        let s1 = "a".repeat(100_000);
+        let file = make_html_file(&db, &s1);
+        let s2 = "a".repeat(100_000);
+        assert!(file.fail_fast_check(&db, &s2));
+    }
+
+    #[test]
+    fn test_large_different_content() {
+        let db = salsa::DatabaseImpl::default();
+        let s1 = "a".repeat(100_000);
+        let file = make_html_file(&db, &s1);
+        let mut s2 = "a".repeat(100_000);
+        s2.replace_range(50_000..50_001, "b"); // one char different
+        assert!(!file.fail_fast_check(&db, &s2));
+    }
+}

--- a/examples/ast-html/src/tests/mod.rs
+++ b/examples/ast-html/src/tests/mod.rs
@@ -1,3 +1,4 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod corpus;
 mod document_links;
+mod files;

--- a/examples/ast-python/src/capabilities/code_actions.rs
+++ b/examples/ast-python/src/capabilities/code_actions.rs
@@ -17,8 +17,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 use crate::generated::FunctionDefinition;
 use auto_lsp::core::dispatch;
+use auto_lsp::default::db::file::File;
 use auto_lsp::default::db::tracked::get_ast;
-use auto_lsp::default::db::{BaseDatabase, File};
+use auto_lsp::default::db::BaseDatabase;
 use auto_lsp::lsp_types::{CodeActionOrCommand, CodeActionParams};
 use auto_lsp::{anyhow, lsp_types};
 

--- a/examples/ast-python/src/capabilities/code_lenses.rs
+++ b/examples/ast-python/src/capabilities/code_lenses.rs
@@ -18,8 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 use crate::generated::FunctionDefinition;
 use auto_lsp::core::ast::AstNode;
 use auto_lsp::core::dispatch;
+use auto_lsp::default::db::file::File;
 use auto_lsp::default::db::tracked::get_ast;
-use auto_lsp::default::db::{BaseDatabase, File};
+use auto_lsp::default::db::BaseDatabase;
 use auto_lsp::lsp_types::{CodeLens, CodeLensParams};
 use auto_lsp::{anyhow, lsp_types};
 

--- a/examples/ast-python/src/capabilities/completion_items.rs
+++ b/examples/ast-python/src/capabilities/completion_items.rs
@@ -17,8 +17,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 use crate::generated::{FunctionDefinition, Identifier, Module};
 use auto_lsp::core::dispatch;
+use auto_lsp::default::db::file::File;
 use auto_lsp::default::db::tracked::get_ast;
-use auto_lsp::default::db::{BaseDatabase, File};
+use auto_lsp::default::db::BaseDatabase;
 use auto_lsp::lsp_types::{
     CompletionContext, CompletionItem, CompletionParams, CompletionResponse,
 };

--- a/examples/ast-python/src/capabilities/hover.rs
+++ b/examples/ast-python/src/capabilities/hover.rs
@@ -19,8 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 use crate::generated::{Identifier, PassStatement};
 use auto_lsp::core::ast::AstNode;
 use auto_lsp::core::dispatch_once;
+use auto_lsp::default::db::file::File;
 use auto_lsp::default::db::tracked::get_ast;
-use auto_lsp::default::db::{BaseDatabase, File};
+use auto_lsp::default::db::BaseDatabase;
 use auto_lsp::lsp_types::{Hover, HoverParams};
 use auto_lsp::{anyhow, lsp_types};
 

--- a/examples/ast-python/src/capabilities/inlay_hints.rs
+++ b/examples/ast-python/src/capabilities/inlay_hints.rs
@@ -19,8 +19,9 @@ use crate::generated::FunctionDefinition;
 use auto_lsp::anyhow;
 use auto_lsp::core::ast::AstNode;
 use auto_lsp::core::dispatch;
+use auto_lsp::default::db::file::File;
 use auto_lsp::default::db::tracked::get_ast;
-use auto_lsp::default::db::{BaseDatabase, File};
+use auto_lsp::default::db::BaseDatabase;
 use auto_lsp::lsp_types::{InlayHint, InlayHintParams};
 
 pub fn inlay_hints(

--- a/examples/ast-python/src/capabilities/semantic_tokens.rs
+++ b/examples/ast-python/src/capabilities/semantic_tokens.rs
@@ -19,8 +19,9 @@ use crate::generated::FunctionDefinition;
 use auto_lsp::core::ast::AstNode;
 use auto_lsp::core::dispatch;
 use auto_lsp::core::semantic_tokens_builder::SemanticTokensBuilder;
+use auto_lsp::default::db::file::File;
 use auto_lsp::default::db::tracked::get_ast;
-use auto_lsp::default::db::{BaseDatabase, File};
+use auto_lsp::default::db::BaseDatabase;
 use auto_lsp::lsp_types::{SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensResult};
 use auto_lsp::{anyhow, define_semantic_token_modifiers, define_semantic_token_types};
 

--- a/examples/ast-python/src/db.rs
+++ b/examples/ast-python/src/db.rs
@@ -18,10 +18,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 use crate::generated::Module;
-use auto_lsp::configure_parsers;
 use auto_lsp::default::db::{BaseDatabase, BaseDb, FileManager};
 use auto_lsp::lsp_types::Url;
 use auto_lsp::texter::core::text::Text;
+use auto_lsp::{configure_parsers, lsp_types};
 
 configure_parsers!(
     PYTHON_PARSERS,
@@ -41,6 +41,7 @@ pub fn create_python_db(source_code: &'static [&str]) -> impl BaseDatabase {
                 .get("python")
                 .expect("Python parser not found"),
             &url,
+            &lsp_types::PositionEncodingKind::UTF8,
             Text::new(source_code.to_string()),
         )
         .expect("Failed to add file");
@@ -68,6 +69,7 @@ pub fn create_python_db_with_logger(
                 .get("python")
                 .expect("Python parser not found"),
             &url,
+            &lsp_types::PositionEncodingKind::UTF8,
             Text::new(source_code.to_string()),
         )
         .expect("Failed to add file");

--- a/examples/ast-python/src/db.rs
+++ b/examples/ast-python/src/db.rs
@@ -18,9 +18,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 use crate::generated::Module;
+use auto_lsp::default::db::file::File;
 use auto_lsp::default::db::{BaseDatabase, BaseDb, FileManager};
 use auto_lsp::lsp_types::Url;
-use auto_lsp::texter::core::text::Text;
 use auto_lsp::{configure_parsers, lsp_types};
 
 configure_parsers!(
@@ -36,15 +36,20 @@ pub fn create_python_db(source_code: &'static [&str]) -> impl BaseDatabase {
     source_code.iter().enumerate().for_each(|(i, source_code)| {
         let url = Url::parse(&format!("file:///test{i}.py")).expect("Failed to parse URL");
 
-        db.add_file_from_texter(
-            PYTHON_PARSERS
-                .get("python")
-                .expect("Python parser not found"),
-            &url,
-            &lsp_types::PositionEncodingKind::UTF8,
-            Text::new(source_code.to_string()),
-        )
-        .expect("Failed to add file");
+        let file = File::from_string()
+            .db(&db)
+            .source(source_code.to_string())
+            .url(&url)
+            .parsers(
+                PYTHON_PARSERS
+                    .get("python")
+                    .expect("Python parser not found"),
+            )
+            .encoding(&lsp_types::PositionEncodingKind::UTF8)
+            .call()
+            .expect("Failed to create file");
+
+        db.add_file(file).expect("Failed to add file");
     });
 
     db
@@ -64,15 +69,20 @@ pub fn create_python_db_with_logger(
     source_code.iter().enumerate().for_each(|(i, source_code)| {
         let url = Url::parse(&format!("file:///test{i}.py")).expect("Failed to parse URL");
 
-        db.add_file_from_texter(
-            PYTHON_PARSERS
-                .get("python")
-                .expect("Python parser not found"),
-            &url,
-            &lsp_types::PositionEncodingKind::UTF8,
-            Text::new(source_code.to_string()),
-        )
-        .expect("Failed to add file");
+        let file = File::from_string()
+            .db(&db)
+            .source(source_code.to_string())
+            .url(&url)
+            .parsers(
+                PYTHON_PARSERS
+                    .get("python")
+                    .expect("Python parser not found"),
+            )
+            .encoding(&lsp_types::PositionEncodingKind::UTF8)
+            .call()
+            .expect("Failed to create file");
+
+        db.add_file(file).expect("Failed to add file");
     });
 
     (db, logs)

--- a/examples/native/Cargo.lock
+++ b/examples/native/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
 name = "auto-lsp-default"
 version = "0.1.2"
 dependencies = [
+ "anyhow",
  "auto-lsp-core",
  "auto-lsp-server",
  "bon",

--- a/examples/native/Cargo.lock
+++ b/examples/native/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "auto-lsp-core",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-codegen"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -131,10 +131,11 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-default"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "auto-lsp-core",
  "auto-lsp-server",
+ "bon",
  "dashmap",
  "fastrace",
  "log",
@@ -150,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "auto-lsp-core",
@@ -197,6 +198,31 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bon"
+version = "3.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61138465baf186c63e8d9b6b613b508cd832cba4ce93cf37ce5f096f91ac1a6"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d1dad34aa19bf02295382f08d9bc40651585bd497266831d40ee6296fb49ca"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "boxcar"
@@ -306,6 +332,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +469,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -646,6 +713,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -960,6 +1033,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1453,12 @@ name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/examples/native/src/main.rs
+++ b/examples/native/src/main.rs
@@ -19,9 +19,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 use ast_python::db::PYTHON_PARSERS;
 use auto_lsp::default::db::{BaseDatabase, BaseDb};
 use auto_lsp::default::server::capabilities::WORKSPACE_PROVIDER;
-use auto_lsp::default::server::file_events::{changed_watched_files, open_text_document};
+use auto_lsp::default::server::file_events::{
+    change_text_document, changed_watched_files, open_text_document,
+};
 use auto_lsp::default::server::workspace_init::WorkspaceInit;
 use auto_lsp::lsp_server::{self, Connection};
+use auto_lsp::lsp_types;
 use auto_lsp::lsp_types::notification::{
     Cancel, DidChangeTextDocument, DidChangeWatchedFiles, DidCloseTextDocument,
     DidOpenTextDocument, DidSaveTextDocument, LogTrace, SetTrace,
@@ -31,7 +34,6 @@ use auto_lsp::server::notification_registry::NotificationRegistry;
 use auto_lsp::server::options::InitOptions;
 use auto_lsp::server::request_registry::RequestRegistry;
 use auto_lsp::server::Session;
-use auto_lsp::{anyhow, lsp_types};
 use native_lsp::requests::GetWorkspaceFiles;
 use std::error::Error;
 use std::panic::RefUnwindSafe;
@@ -97,13 +99,7 @@ fn on_notifications<Db: BaseDatabase + Clone + RefUnwindSafe>(
 ) -> &mut NotificationRegistry<Db> {
     registry
         .on_mut::<DidOpenTextDocument, _>(|s, p| Ok(open_text_document(s, p)?))
-        .on_mut::<DidChangeTextDocument, _>(|s, p| {
-            let file =
-                s.db.get_file(&p.text_document.uri)
-                    .ok_or_else(|| anyhow::format_err!("File not found in workspace"))?;
-            file.update_edit(&mut s.db, &p)?;
-            Ok(())
-        })
+        .on_mut::<DidChangeTextDocument, _>(|s, p| Ok(change_text_document(s, p)?))
         .on_mut::<DidChangeWatchedFiles, _>(|s, p| Ok(changed_watched_files(s, p)?))
         .on_mut::<Cancel, _>(|s, p| {
             let id: lsp_server::RequestId = match p.id {

--- a/examples/vscode-native/server/Cargo.lock
+++ b/examples/vscode-native/server/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "auto-lsp-core",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-codegen"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -109,10 +109,11 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-default"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "auto-lsp-core",
  "auto-lsp-server",
+ "bon",
  "dashmap",
  "fastrace",
  "log",
@@ -128,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "auto-lsp-core",
@@ -160,6 +161,31 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "bon"
+version = "3.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61138465baf186c63e8d9b6b613b508cd832cba4ce93cf37ce5f096f91ac1a6"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d1dad34aa19bf02295382f08d9bc40651585bd497266831d40ee6296fb49ca"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "boxcar"
@@ -272,6 +298,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +411,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -557,6 +624,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -801,6 +874,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1133,6 +1216,12 @@ name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/examples/vscode-native/server/Cargo.lock
+++ b/examples/vscode-native/server/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
 name = "auto-lsp-default"
 version = "0.1.2"
 dependencies = [
+ "anyhow",
  "auto-lsp-core",
  "auto-lsp-server",
  "bon",

--- a/examples/vscode-native/server/src/main.rs
+++ b/examples/vscode-native/server/src/main.rs
@@ -31,7 +31,8 @@ use ast_python::capabilities::semantic_tokens::{
 use ast_python::capabilities::workspace_diagnostics::workspace_diagnostics;
 use ast_python::capabilities::workspace_symbols::workspace_symbols;
 use ast_python::db::PYTHON_PARSERS;
-use auto_lsp::default::db::{BaseDatabase, BaseDb, FileManager};
+use auto_lsp::anyhow;
+use auto_lsp::default::db::{BaseDatabase, BaseDb};
 use auto_lsp::default::server::capabilities::{
     semantic_tokens_provider, TEXT_DOCUMENT_SYNC, WORKSPACE_PROVIDER,
 };
@@ -161,7 +162,11 @@ fn on_notifications<Db: BaseDatabase + Clone + RefUnwindSafe>(
     registry
         .on_mut::<DidOpenTextDocument, _>(|s, p| Ok(open_text_document(s, p)?))
         .on_mut::<DidChangeTextDocument, _>(|s, p| {
-            Ok(s.db.update(&p.text_document.uri, &p.content_changes)?)
+            let file =
+                s.db.get_file(&p.text_document.uri)
+                    .ok_or_else(|| anyhow::format_err!("File not found in workspace"))?;
+            file.update_edit(&mut s.db, &p)?;
+            Ok(())
         })
         .on_mut::<DidChangeWatchedFiles, _>(|s, p| Ok(changed_watched_files(s, p)?))
         .on_mut::<Cancel, _>(|s, p| {

--- a/examples/vscode-native/server/src/main.rs
+++ b/examples/vscode-native/server/src/main.rs
@@ -31,12 +31,13 @@ use ast_python::capabilities::semantic_tokens::{
 use ast_python::capabilities::workspace_diagnostics::workspace_diagnostics;
 use ast_python::capabilities::workspace_symbols::workspace_symbols;
 use ast_python::db::PYTHON_PARSERS;
-use auto_lsp::anyhow;
 use auto_lsp::default::db::{BaseDatabase, BaseDb};
 use auto_lsp::default::server::capabilities::{
     semantic_tokens_provider, TEXT_DOCUMENT_SYNC, WORKSPACE_PROVIDER,
 };
-use auto_lsp::default::server::file_events::{changed_watched_files, open_text_document};
+use auto_lsp::default::server::file_events::{
+    change_text_document, changed_watched_files, open_text_document,
+};
 use auto_lsp::default::server::workspace_init::WorkspaceInit;
 use auto_lsp::lsp_server::{self, Connection};
 use auto_lsp::lsp_types::notification::{
@@ -161,13 +162,7 @@ fn on_notifications<Db: BaseDatabase + Clone + RefUnwindSafe>(
 ) -> &mut NotificationRegistry<Db> {
     registry
         .on_mut::<DidOpenTextDocument, _>(|s, p| Ok(open_text_document(s, p)?))
-        .on_mut::<DidChangeTextDocument, _>(|s, p| {
-            let file =
-                s.db.get_file(&p.text_document.uri)
-                    .ok_or_else(|| anyhow::format_err!("File not found in workspace"))?;
-            file.update_edit(&mut s.db, &p)?;
-            Ok(())
-        })
+        .on_mut::<DidChangeTextDocument, _>(|s, p| Ok(change_text_document(s, p)?))
         .on_mut::<DidChangeWatchedFiles, _>(|s, p| Ok(changed_watched_files(s, p)?))
         .on_mut::<Cancel, _>(|s, p| {
             let id: lsp_server::RequestId = match p.id {

--- a/examples/vscode-wasi/server/Cargo.lock
+++ b/examples/vscode-wasi/server/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
 name = "auto-lsp-default"
 version = "0.1.2"
 dependencies = [
+ "anyhow",
  "auto-lsp-core",
  "auto-lsp-server",
  "bon",

--- a/examples/vscode-wasi/server/Cargo.lock
+++ b/examples/vscode-wasi/server/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "auto-lsp-core",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-codegen"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -94,10 +94,11 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-default"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "auto-lsp-core",
  "auto-lsp-server",
+ "bon",
  "dashmap",
  "fastrace",
  "log",
@@ -113,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "auto-lsp-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "auto-lsp-core",
@@ -145,6 +146,31 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bon"
+version = "3.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61138465baf186c63e8d9b6b613b508cd832cba4ce93cf37ce5f096f91ac1a6"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d1dad34aa19bf02295382f08d9bc40651585bd497266831d40ee6296fb49ca"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "boxcar"
@@ -237,6 +263,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +376,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -498,6 +565,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -736,6 +809,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1135,12 @@ name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/examples/vscode-wasi/server/src/main.rs
+++ b/examples/vscode-wasi/server/src/main.rs
@@ -31,7 +31,8 @@ use ast_python::capabilities::semantic_tokens::{
 use ast_python::capabilities::workspace_diagnostics::workspace_diagnostics;
 use ast_python::capabilities::workspace_symbols::workspace_symbols;
 use ast_python::db::PYTHON_PARSERS;
-use auto_lsp::default::db::{BaseDatabase, BaseDb, FileManager};
+use auto_lsp::anyhow;
+use auto_lsp::default::db::{BaseDatabase, BaseDb};
 use auto_lsp::default::server::capabilities::{
     semantic_tokens_provider, TEXT_DOCUMENT_SYNC, WORKSPACE_PROVIDER,
 };
@@ -151,7 +152,11 @@ fn on_notifications<Db: BaseDatabase + Clone + RefUnwindSafe>(
     registry
         .on_mut::<DidOpenTextDocument, _>(|s, p| Ok(open_text_document(s, p)?))
         .on_mut::<DidChangeTextDocument, _>(|s, p| {
-            Ok(s.db.update(&p.text_document.uri, &p.content_changes)?)
+            let file =
+                s.db.get_file(&p.text_document.uri)
+                    .ok_or_else(|| anyhow::format_err!("File not found in workspace"))?;
+            file.update_edit(&mut s.db, &p)?;
+            Ok(())
         })
         .on_mut::<DidChangeWatchedFiles, _>(|s, p| Ok(changed_watched_files(s, p)?))
         .on_mut::<Cancel, _>(|s, p| {

--- a/examples/vscode-wasi/server/src/main.rs
+++ b/examples/vscode-wasi/server/src/main.rs
@@ -31,12 +31,13 @@ use ast_python::capabilities::semantic_tokens::{
 use ast_python::capabilities::workspace_diagnostics::workspace_diagnostics;
 use ast_python::capabilities::workspace_symbols::workspace_symbols;
 use ast_python::db::PYTHON_PARSERS;
-use auto_lsp::anyhow;
 use auto_lsp::default::db::{BaseDatabase, BaseDb};
 use auto_lsp::default::server::capabilities::{
     semantic_tokens_provider, TEXT_DOCUMENT_SYNC, WORKSPACE_PROVIDER,
 };
-use auto_lsp::default::server::file_events::{changed_watched_files, open_text_document};
+use auto_lsp::default::server::file_events::{
+    change_text_document, changed_watched_files, open_text_document,
+};
 use auto_lsp::default::server::workspace_init::WorkspaceInit;
 use auto_lsp::lsp_server::{self, Connection};
 use auto_lsp::lsp_types::notification::{
@@ -151,13 +152,7 @@ fn on_notifications<Db: BaseDatabase + Clone + RefUnwindSafe>(
 ) -> &mut NotificationRegistry<Db> {
     registry
         .on_mut::<DidOpenTextDocument, _>(|s, p| Ok(open_text_document(s, p)?))
-        .on_mut::<DidChangeTextDocument, _>(|s, p| {
-            let file =
-                s.db.get_file(&p.text_document.uri)
-                    .ok_or_else(|| anyhow::format_err!("File not found in workspace"))?;
-            file.update_edit(&mut s.db, &p)?;
-            Ok(())
-        })
+        .on_mut::<DidChangeTextDocument, _>(|s, p| Ok(change_text_document(s, p)?))
         .on_mut::<DidChangeWatchedFiles, _>(|s, p| Ok(changed_watched_files(s, p)?))
         .on_mut::<Cancel, _>(|s, p| {
             let id: lsp_server::RequestId = match p.id {


### PR DESCRIPTION
- Introduced Span struct, a newtype wrapper around tree-sitter’s Range, which can be easily converted into an LSP range.

- Added support for UTF-8, UTF-16, and UTF-32 character encodings in the Document module for position-related functions.

- The Salsa File input now provides methods for creating, updating, and deleting itself, instead of relying on Session.
This is implemented via [bon builders](https://docs.rs/bon/latest/bon/), making the API more ergonomic.

- The File input now also storesTextDocument version sent by the IDE.