### PR TITLE
feat(default): callbacks

### DIFF
--- a/crates/default/src/db/mod.rs
+++ b/crates/default/src/db/mod.rs
@@ -45,7 +45,7 @@ pub type FileCallBack = fn(File) -> bool;
 #[derive(Default, Clone)]
 pub struct BaseDb {
     storage: Storage<Self>,
-    pub(crate) files: DashMap<Url, File>,
+    pub files: DashMap<Url, File>,
     pub(crate) on_file_added: Option<FileCallBack>,
     pub(crate) on_file_removed: Option<FileCallBack>,
 }

--- a/crates/default/src/db/mod.rs
+++ b/crates/default/src/db/mod.rs
@@ -29,6 +29,11 @@ use dashmap::{DashMap, Entry};
 use lsp_types::Url;
 use salsa::{Database, Storage};
 
+/// A callback function that is called when a file is added or removed from the database.
+///
+/// Returns a boolean indicating whether the file should be added/removed or not.
+pub type FileCallBack = fn(File) -> bool;
+
 /// Base database that stores files.
 ///
 /// Files are stored in a [`DashMap`] for concurrent access.
@@ -41,6 +46,8 @@ use salsa::{Database, Storage};
 pub struct BaseDb {
     storage: Storage<Self>,
     pub(crate) files: DashMap<Url, File>,
+    pub(crate) on_file_added: Option<FileCallBack>,
+    pub(crate) on_file_removed: Option<FileCallBack>,
 }
 
 impl BaseDb {
@@ -51,6 +58,7 @@ impl BaseDb {
         Self {
             storage: Storage::new(event_callback),
             files: DashMap::default(),
+            ..Default::default()
         }
     }
 }
@@ -65,6 +73,16 @@ pub trait BaseDatabase: Database {
     fn get_file(&self, url: &Url) -> Option<File> {
         self.get_files().get(url).map(|file| *file)
     }
+
+    fn on_file_added_cb(&self) -> Option<FileCallBack> {
+        None
+    }
+    fn on_file_removed_cb(&self) -> Option<FileCallBack> {
+        None
+    }
+
+    fn set_on_file_added_cb(&mut self, _callback: Option<FileCallBack>) {}
+    fn set_on_file_removed_cb(&mut self, _callback: Option<FileCallBack>) {}
 }
 
 /// Implementation of [`salsa::Database`] for [`BaseDb`].
@@ -78,6 +96,22 @@ impl BaseDatabase for BaseDb {
     fn get_files(&self) -> &DashMap<Url, File> {
         &self.files
     }
+
+    fn on_file_added_cb(&self) -> Option<FileCallBack> {
+        self.on_file_added
+    }
+
+    fn on_file_removed_cb(&self) -> Option<FileCallBack> {
+        self.on_file_removed
+    }
+
+    fn set_on_file_added_cb(&mut self, callback: Option<FileCallBack>) {
+        self.on_file_added = callback;
+    }
+
+    fn set_on_file_removed_cb(&mut self, callback: Option<FileCallBack>) {
+        self.on_file_removed = callback;
+    }
 }
 
 /// Trait for managing files in the database.
@@ -90,7 +124,16 @@ pub trait FileManager: BaseDatabase + salsa::Database {
                 uri: file.url(self).clone(),
             }),
             Entry::Vacant(entry) => {
-                entry.insert(file);
+                match self.on_file_added_cb() {
+                    Some(cb) => {
+                        if cb(file) {
+                            entry.insert(file);
+                        };
+                    }
+                    None => {
+                        entry.insert(file);
+                    }
+                };
                 Ok(())
             }
         }
@@ -99,7 +142,16 @@ pub trait FileManager: BaseDatabase + salsa::Database {
     fn remove_file(&mut self, url: &Url) -> Result<(), DataBaseError> {
         match self.get_files().entry(url.clone()) {
             Entry::Occupied(entry) => {
-                entry.remove();
+                match self.on_file_removed_cb() {
+                    Some(cb) => {
+                        if cb(*entry.get()) {
+                            entry.remove();
+                        };
+                    }
+                    None => {
+                        entry.remove();
+                    }
+                };
                 Ok(())
             }
             Entry::Vacant(_) => Err(DataBaseError::FileNotFound { uri: url.clone() }),

--- a/crates/server/src/init.rs
+++ b/crates/server/src/init.rs
@@ -66,6 +66,7 @@ impl<Db: salsa::Database> Session<Db> {
             task_receiver,
             task_sender,
             task_pool: Pool::new(max_threads),
+            on_error: None,
         }
     }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -31,6 +31,11 @@ pub mod vendored;
 pub(crate) type ReqHandler<Db> = fn(&mut Session<Db>, lsp_server::Response);
 type ReqQueue<Db> = lsp_server::ReqQueue<String, ReqHandler<Db>>;
 
+/// Callback for unhandled errors from `with_db` handlers.
+///
+/// Called before the default error handling (error response for requests, `window/showMessage` for notifications).
+pub type ErrorCallback = fn(&anyhow::Error);
+
 /// Main session object that holds both lsp server connection and initialization options.
 pub struct Session<Db: salsa::Database> {
     /// Initialization options provided by the library user.
@@ -48,28 +53,19 @@ pub struct Session<Db: salsa::Database> {
     pub req_queue: ReqQueue<Db>,
     pub connection: Connection,
     pub db: Db,
+    /// Optional callback for errors from `with_db` handlers that salsa does not handle.
+    pub on_error: Option<ErrorCallback>,
 }
 
-impl<Db: salsa::Database + Clone> Session<Db> {
-    pub(crate) fn snapshot(&self) -> DbSnapShot<Db> {
-        DbSnapShot {
-            db: self.db.clone(),
-        }
-    }
-}
-
-pub struct DbSnapShot<Db: salsa::Database + Send> {
-    db: Db,
-}
-
-/// Perform an operation on the database that may be cancelled.
+/// Perform an operation on a snapshot of the database that may be cancelled.
 ///
 /// From: https://github.com/rust-lang/rust-analyzer/blob/4e4aee41c969e86adefdb8c687e2e91bb101329a/crates/ide/src/lib.rs#L862
-impl<Db: salsa::Database + Clone + RefUnwindSafe> DbSnapShot<Db> {
+impl<Db: salsa::Database + RefUnwindSafe> Session<Db> {
     pub fn with_db<F, T>(&self, f: F) -> Result<T, salsa::Cancelled>
     where
         F: FnOnce(&Db) -> T + std::panic::UnwindSafe,
     {
-        salsa::Cancelled::catch(|| f(&self.db))
+        let db = &self.db;
+        salsa::Cancelled::catch(|| f(db))
     }
 }

--- a/crates/server/src/notification_registry.rs
+++ b/crates/server/src/notification_registry.rs
@@ -103,17 +103,23 @@ impl<Db: salsa::Database + Clone + Send + RefUnwindSafe> NotificationRegistry<Db
     ) {
         let params = not.params;
 
-        let snapshot = session.snapshot();
+        let db = session.db.clone();
         let cb = Arc::clone(&callback.0);
         let intent = callback.1;
         let sender = session.task_sender.clone();
+        let on_error = session.on_error;
         session.task_pool.spawn(
             intent,
-            std::panic::AssertUnwindSafe(move || match snapshot.with_db(|db| cb(db, params)) {
-                Err(e) => log::warn!("Cancelled notification: {e}"),
-                Ok(result) => {
-                    if let Err(e) = result {
-                        sender.send(Task::NotificationError(e)).unwrap();
+            std::panic::AssertUnwindSafe(move || {
+                match salsa::Cancelled::catch(|| cb(&db, params)) {
+                    Err(e) => log::warn!("Cancelled notification: {e}"),
+                    Ok(result) => {
+                        if let Err(e) = result {
+                            if let Some(on_error) = on_error {
+                                on_error(&e);
+                            }
+                            sender.send(Task::NotificationError(e)).unwrap();
+                        }
                     }
                 }
             }),

--- a/crates/server/src/request_registry.rs
+++ b/crates/server/src/request_registry.rs
@@ -106,15 +106,16 @@ impl<Db: salsa::Database + Clone + Send + RefUnwindSafe> RequestRegistry<Db> {
         let params = req.params;
         let id = req.id.clone();
 
-        let snapshot = session.snapshot();
+        let db = session.db.clone();
         let cb = Arc::clone(&callback.0);
         let intent = callback.1;
         let sender = session.task_sender.clone();
+        let on_error = session.on_error;
         session.task_pool.spawn(
             intent,
             std::panic::AssertUnwindSafe(move || {
                 let cb = cb.clone();
-                match snapshot.with_db(|db| cb(db, params)) {
+                match salsa::Cancelled::catch(|| cb(&db, params)) {
                     Err(e) => {
                         log::warn!("Cancelled request: {e}");
                     }
@@ -127,6 +128,9 @@ impl<Db: salsa::Database + Clone + Send + RefUnwindSafe> RequestRegistry<Db> {
                             }))
                             .unwrap(),
                         Err(e) => {
+                            if let Some(on_error) = on_error {
+                                on_error(&e);
+                            }
                             sender
                                 .send(Task::Response(Self::response_error(id, e)))
                                 .unwrap();

--- a/examples/ast-python/src/tests/db/callbacks.rs
+++ b/examples/ast-python/src/tests/db/callbacks.rs
@@ -1,0 +1,105 @@
+/*
+This file is part of auto-lsp.
+Copyright (C) 2025 CLAUZEL Adrien
+
+auto-lsp is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+use crate::db::PYTHON_PARSERS;
+use auto_lsp::default::db::file::File;
+use auto_lsp::default::db::{BaseDatabase, BaseDb, FileManager};
+use auto_lsp::lsp_types::{self, Url};
+
+fn create_file(db: &BaseDb, name: &str, source: &str) -> File {
+    let url = Url::parse(&format!("file:///{name}.py")).expect("Failed to parse URL");
+    File::from_string()
+        .db(db)
+        .source(source.to_string())
+        .url(&url)
+        .parsers(
+            PYTHON_PARSERS
+                .get("python")
+                .expect("Python parser not found"),
+        )
+        .encoding(&lsp_types::PositionEncodingKind::UTF8)
+        .call()
+        .expect("Failed to create file")
+}
+
+#[test]
+fn on_file_added_allows() {
+    let mut db = BaseDb::default();
+    db.set_on_file_added_cb(Some(|_| true));
+
+    let file = create_file(&db, "test0", "def foo(): pass");
+    db.add_file(file).expect("Failed to add file");
+
+    assert_eq!(db.get_files().len(), 1);
+}
+
+#[test]
+fn on_file_added_vetoes() {
+    let mut db = BaseDb::default();
+    db.set_on_file_added_cb(Some(|_| false));
+
+    let file = create_file(&db, "test0", "def foo(): pass");
+    db.add_file(file).expect("add_file should return Ok even when vetoed");
+
+    assert_eq!(db.get_files().len(), 0);
+}
+
+#[test]
+fn on_file_removed_allows() {
+    let mut db = BaseDb::default();
+
+    let file = create_file(&db, "test0", "def foo(): pass");
+    db.add_file(file).expect("Failed to add file");
+    assert_eq!(db.get_files().len(), 1);
+
+    db.set_on_file_removed_cb(Some(|_| true));
+
+    db.remove_file(&Url::parse("file:///test0.py").unwrap())
+        .expect("Failed to remove file");
+
+    assert_eq!(db.get_files().len(), 0);
+}
+
+#[test]
+fn on_file_removed_vetoes() {
+    let mut db = BaseDb::default();
+
+    let file = create_file(&db, "test0", "def foo(): pass");
+    db.add_file(file).expect("Failed to add file");
+    assert_eq!(db.get_files().len(), 1);
+
+    db.set_on_file_removed_cb(Some(|_| false));
+
+    db.remove_file(&Url::parse("file:///test0.py").unwrap())
+        .expect("remove_file should return Ok even when vetoed");
+
+    assert_eq!(db.get_files().len(), 1);
+}
+
+#[test]
+fn no_callback_default_behavior() {
+    let mut db = BaseDb::default();
+
+    let file = create_file(&db, "test0", "def foo(): pass");
+    db.add_file(file).expect("Failed to add file");
+    assert_eq!(db.get_files().len(), 1);
+
+    db.remove_file(&Url::parse("file:///test0.py").unwrap())
+        .expect("Failed to remove file");
+    assert_eq!(db.get_files().len(), 0);
+}

--- a/examples/ast-python/src/tests/db/mod.rs
+++ b/examples/ast-python/src/tests/db/mod.rs
@@ -1,2 +1,3 @@
+mod callbacks;
 mod salsa;
 mod type_errors;

--- a/examples/native/src/main.rs
+++ b/examples/native/src/main.rs
@@ -35,7 +35,7 @@ use auto_lsp::server::notification_registry::NotificationRegistry;
 use auto_lsp::server::options::InitOptions;
 use auto_lsp::server::request_registry::RequestRegistry;
 use auto_lsp::server::vendored::intent::ThreadIntent;
-use native_lsp::requests::GetWorkspaceFiles;
+use native_lsp::requests::{GetWorkspaceFiles, TriggerError};
 use std::error::Error;
 use std::panic::RefUnwindSafe;
 
@@ -71,6 +71,13 @@ fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
     let mut notification_registry = NotificationRegistry::<BaseDb>::default();
 
     request_registry.on::<GetWorkspaceFiles, _>(ThreadIntent::Worker, |s, _| Ok(s.get_urls()));
+    request_registry.on::<TriggerError, _>(ThreadIntent::Worker, |_s, _| {
+        Err(auto_lsp::anyhow::anyhow!("test error"))
+    });
+
+    session.on_error = Some(|e| {
+        eprintln!("on_error callback: {e}");
+    });
 
     // Initialize the session with the client's initialization options.
     // This will also add all documents, parse and send diagnostics.

--- a/examples/native/src/requests.rs
+++ b/examples/native/src/requests.rs
@@ -33,3 +33,17 @@ impl Request for GetWorkspaceFiles {
     type Result = Vec<String>;
     const METHOD: &'static str = "custom/getWorkspaceFiles";
 }
+
+pub struct TriggerError {}
+
+impl TriggerError {
+    pub fn request(id: u32) -> String {
+        format!(r#"{{"jsonrpc":"2.0","id":{id},"method":"custom/triggerError"}}"#)
+    }
+}
+
+impl Request for TriggerError {
+    type Params = ();
+    type Result = ();
+    const METHOD: &'static str = "custom/triggerError";
+}

--- a/examples/native/src/tests/error_handling.rs
+++ b/examples/native/src/tests/error_handling.rs
@@ -1,0 +1,77 @@
+/*
+This file is part of auto-lsp.
+Copyright (C) 2025 CLAUZEL Adrien
+
+auto-lsp is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+use rstest::{fixture, rstest};
+
+use crate::requests::TriggerError;
+use crate::server::TestServer;
+
+pub static CLIENT_CAPABILITIES: &str = include_str!("client.json");
+
+#[fixture]
+async fn stdio_server() -> TestServer {
+    let testbed_dir = std::env::current_dir().unwrap().join("src/testbed");
+    let mut server = TestServer::stdio().await.unwrap();
+
+    server
+        .write_message(
+            CLIENT_CAPABILITIES
+                .replace(
+                    "file:///testbed",
+                    format!("file:///{}", testbed_dir.to_str().unwrap()).as_str(),
+                )
+                .as_str(),
+        )
+        .await
+        .unwrap();
+
+    server
+        .write_message(r#"{"jsonrpc": "2.0", "method": "initialized", "params": {}}"#)
+        .await
+        .unwrap();
+
+    server.wait_for_messages(1).await;
+
+    assert!(server.responses.read().await[0].contains(r#""id":1"#));
+    server.responses.write().await.clear();
+
+    server
+}
+
+#[rstest]
+#[tokio::test]
+async fn trigger_error_request(
+    #[future] mut stdio_server: TestServer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stdio_server = stdio_server.await;
+
+    stdio_server
+        .write_message(&TriggerError::request(2))
+        .await?;
+
+    stdio_server.wait_for_messages(1).await;
+
+    let responses = stdio_server.responses.read().await;
+
+    // The response should contain an error with code -32803 (RequestFailed)
+    assert!(responses[0].contains(r#""error"#));
+    assert!(responses[0].contains("test error"));
+    assert!(responses[0].contains("-32803"));
+
+    Ok(())
+}

--- a/examples/native/src/tests/mod.rs
+++ b/examples/native/src/tests/mod.rs
@@ -16,4 +16,5 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+mod error_handling;
 mod file_notifications;


### PR DESCRIPTION
- Add callbacks to the FileManager trait when a file is about to be added or removed, allowing it to decide whether the file should be added/removed or handled separately.
- Add a callback that triggers when a request or notification handler panics, before sending an error to the LSP client.