### PR TITLE
Use `partition_point` for `descendant_at`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ lsp-types = { workspace = true }
 anyhow = { workspace = true }
 parking_lot = { workspace = true }
 salsa = { workspace = true }
-texter = { workspace = true, default-features = false }
+texter = { workspace = true }
 auto-lsp-core = { workspace = true }
 auto-lsp-server = { workspace = true, optional = true }
 auto-lsp-default = { workspace = true, optional = true }

--- a/crates/core/src/ast/node.rs
+++ b/crates/core/src/ast/node.rs
@@ -77,7 +77,7 @@ pub trait AstNode: std::fmt::Debug + Send + Sync + DowncastSync {
 
     /// Returns the LSP-compatible range of this node.
     fn get_lsp_range(&self, document: &Document) -> Result<lsp_types::Range, DocumentError> {
-        document.ts_range_to_range(self.get_range())
+        document.denormalize_range(self.get_range())
     }
 
     /// Returns `true` if this node is a MISSING node.

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -16,13 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-// `texter` 0.3.0 made `GridIndex::normalize`/`denormalize` take `&Text` (instead of `&mut Text`),
-// which finally lets us route all encoding-aware position conversions through texter without
-// invalidating salsa queries. This module is now a thin wrapper around `Text` and `Tree`:
-// what used to be a handful of manual UTF-8/16/32 loops and a duplicated `Encoding` enum is
-// gone, and the public surface is reduced to what consumers actually call. Callers receive
-// LSP positions in the negotiated encoding and never see `GridIndex` or normalization itself.
-
 use lsp_types::PositionEncodingKind;
 use texter::{change::GridIndex, core::text::Text};
 use texter_impl::{change::WrapChange, updateable::WrapTree};
@@ -95,33 +88,45 @@ impl Document {
         Ok(())
     }
 
-    /// Converts an LSP [`lsp_types::Position`] (in the negotiated encoding) to a byte offset.
-    ///
-    /// Uses texter's [`GridIndex::normalize`] to convert the encoded column to a UTF-8 column,
-    /// then adds the row's start byte. An out-of-bounds row surfaces as a
-    /// [`texter::error::Error::OutOfBoundsRow`] wrapped in [`DocumentError::Texter`].
-    pub fn offset_at(&self, position: lsp_types::Position) -> Result<usize, DocumentError> {
+    /// Converts an LSP [`lsp_types::Range`] from the client encoding to UTF-8, returning a new range.
+    /// Mirrors texter's own [`GridIndex::normalize`].
+    pub fn normalize_range(
+        &self,
+        position: &lsp_types::Range,
+    ) -> Result<lsp_types::Range, DocumentError> {
+        let start = self.normalize_position(&position.start)?;
+        let end = self.normalize_position(&position.end)?;
+
+        Ok(lsp_types::Range { start, end })
+    }
+
+    /// Converts an LSP [`lsp_types::Position`] from the client encoding to UTF-8, returning a new position.
+    /// Mirrors texter's own [`GridIndex::normalize`].
+    pub fn normalize_position(
+        &self,
+        position: &lsp_types::Position,
+    ) -> Result<lsp_types::Position, DocumentError> {
         let mut grid = GridIndex {
             row: position.line as usize,
             col: position.character as usize,
         };
         grid.normalize(&self.texter)?;
-        let row_start = self
-            .texter
-            .br_indexes
-            .row_start(grid.row)
-            .expect("row validated by normalize");
-        Ok(row_start + grid.col)
+
+        Ok(lsp_types::Position {
+            line: grid.row as u32,
+            character: grid.col as u32,
+        })
     }
 
     /// Converts a tree-sitter [`tree_sitter::Range`] to an LSP [`lsp_types::Range`],
-    /// adjusting columns to the document's negotiated encoding.
-    pub fn ts_range_to_range(
+    /// adjusting columns to the LSP client encoding.
+    /// Mirrors texter's own [`GridIndex::denormalize`].
+    pub fn denormalize_range(
         &self,
         range: &tree_sitter::Range,
     ) -> Result<lsp_types::Range, DocumentError> {
-        let start = self.encoded_point(range.start_point)?;
-        let end = self.encoded_point(range.end_point)?;
+        let start = self.denormalize_point(range.start_point)?;
+        let end = self.denormalize_point(range.end_point)?;
         Ok(lsp_types::Range {
             start: lsp_types::Position {
                 line: start.row as u32,
@@ -134,7 +139,10 @@ impl Document {
         })
     }
 
-    fn encoded_point(&self, point: Point) -> Result<Point, DocumentError> {
+    /// Converts a tree-sitter [`tree_sitter::Point`] to an LSP [`lsp_types::Position`],
+    /// adjusting columns to the LSP client encoding.
+    /// Mirrors texter's own [`GridIndex::denormalize`].
+    pub fn denormalize_point(&self, point: Point) -> Result<Point, DocumentError> {
         let mut grid = GridIndex::from(point);
         grid.denormalize(&self.texter)?;
         Ok(Point::from(grid))
@@ -176,7 +184,8 @@ mod test {
     }
 
     #[rstest]
-    fn offset_at(mut parser: Parser) {
+    fn normalize(mut parser: Parser) {
+        // All-ASCII source, so encoded columns equal UTF-8 columns.
         let source = "Apples\nBashdjad\nashdkasdh\nasdsad";
         let document = Document::new(
             source.into(),
@@ -186,63 +195,59 @@ mod test {
 
         assert_eq!(&document.texter.br_indexes.0, &[0, 6, 15, 25]);
 
+        let normalized = |line, character| {
+            let pos = Position { line, character };
+            document.normalize_position(&pos).unwrap()
+        };
+
         assert_eq!(
-            document
-                .offset_at(Position {
-                    line: 0,
-                    character: 0
-                })
-                .unwrap(),
-            0
+            normalized(0, 0),
+            Position {
+                line: 0,
+                character: 0
+            }
         );
         assert_eq!(
-            document
-                .offset_at(Position {
-                    line: 0,
-                    character: 5
-                })
-                .unwrap(),
-            5
+            normalized(0, 5),
+            Position {
+                line: 0,
+                character: 5
+            }
         );
         assert_eq!(
-            document
-                .offset_at(Position {
-                    line: 1,
-                    character: 3
-                })
-                .unwrap(),
-            10
+            normalized(1, 3),
+            Position {
+                line: 1,
+                character: 3
+            }
         );
         assert_eq!(
-            document
-                .offset_at(Position {
-                    line: 3,
-                    character: 5
-                })
-                .unwrap(),
-            31
+            normalized(3, 5),
+            Position {
+                line: 3,
+                character: 5
+            }
         );
 
         // Line out of bounds surfaces as a texter error wrapped in DocumentError.
+        let oob = Position {
+            line: 10,
+            character: 0,
+        };
         assert!(matches!(
-            document.offset_at(Position {
-                line: 10,
-                character: 0
-            }),
+            document.normalize_position(&oob),
             Err(DocumentError::Texter(TexterError::TexterError(
                 texter::error::Error::OutOfBoundsRow { .. }
             )))
         ));
 
-        // Column past encoded line length is clamped by texter to the end of the line.
+        // Column past the line length is clamped by texter to the end of the line ("Bashdjad").
         assert_eq!(
-            document
-                .offset_at(Position {
-                    line: 1,
-                    character: 100
-                })
-                .unwrap(),
-            15
+            normalized(1, 100),
+            Position {
+                line: 1,
+                character: 8
+            }
         );
     }
 
@@ -263,7 +268,7 @@ mod test {
         let text_node = element.named_child(1).expect("text node");
 
         assert_eq!(
-            document.ts_range_to_range(&text_node.range()).unwrap(),
+            document.denormalize_range(&text_node.range()).unwrap(),
             lsp_types::Range {
                 start: Position {
                     line: 0,

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -57,7 +57,7 @@ impl ParseError {
             ParseError::LexerError { span: range, error } => (range, error.to_string()),
         };
         Ok(lsp_types::Diagnostic {
-            range: doc.ts_range_to_range(range)?,
+            range: doc.denormalize_range(range)?,
             severity: Some(lsp_types::DiagnosticSeverity::ERROR),
             message,
             code: Some(lsp_types::NumberOrString::String("AUTO_LSP".into())),

--- a/crates/default/src/db/tracked.rs
+++ b/crates/default/src/db/tracked.rs
@@ -18,7 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 use super::lexer::get_tree_sitter_errors;
 use super::{BaseDatabase, File};
 use auto_lsp_core::ast::AstNode;
+use auto_lsp_core::document::Document;
 use auto_lsp_core::errors::ParseErrorAccumulator;
+use lsp_types::Position;
 use salsa::Accumulator;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -86,20 +88,29 @@ impl ParsedAst {
         self.nodes.first()
     }
 
-    /// Returns the deepest node that contains the given offset.
-    pub fn descendant_at(&self, offset: usize) -> Option<&Box<dyn AstNode>> {
+    /// Returns the deepest node that contains the given LSP position.
+    ///
+    /// The position is interpreted in the client's negotiated encoding and normalized
+    /// (via [`Document::normalize_position`]) before being matched against node ranges.
+    /// Returns`None` if the position is out of bounds.
+    pub fn descendant_for_position(
+        &self,
+        doc: &Document,
+        position: &Position,
+    ) -> Option<&Box<dyn AstNode>> {
         debug_assert!(self.nodes.is_sorted());
 
-        // Uses partition_point to find all nodes with `start_byte <= offset`,
-        let idx = self
-            .nodes
-            .partition_point(|f| f.get_range().start_byte <= offset);
+        let position = doc.normalize_position(position).ok()?;
+        let position = (position.line as usize, position.character as usize);
 
-        // then walks backward to find the deepest one whose `end_byte >= offset`.
-        // so the first match is the most specific (deepest) node.
-        self.nodes[..idx]
-            .iter()
-            .rev()
-            .find(|f| f.get_range().end_byte >= offset)
+        let idx = self.nodes.partition_point(|f| {
+            let s = f.get_range().start_point;
+            (s.row, s.column) <= position
+        });
+
+        self.nodes[..idx].iter().rev().find(|f| {
+            let e = f.get_range().end_point;
+            (e.row, e.column) >= position
+        })
     }
 }

--- a/crates/default/src/db/tracked.rs
+++ b/crates/default/src/db/tracked.rs
@@ -86,25 +86,20 @@ impl ParsedAst {
         self.nodes.first()
     }
 
-    /// Returns the first node that contains the given offset.
-    ///
-    /// This method uses binary search to find the node.
+    /// Returns the deepest node that contains the given offset.
     pub fn descendant_at(&self, offset: usize) -> Option<&Box<dyn AstNode>> {
         debug_assert!(self.nodes.is_sorted());
 
-        let result = self
+        // Uses partition_point to find all nodes with `start_byte <= offset`,
+        let idx = self
             .nodes
-            .binary_search_by(|f| {
-                let range = f.get_range();
-                if range.start_byte <= offset && offset <= range.end_byte {
-                    std::cmp::Ordering::Equal
-                } else if range.start_byte > offset {
-                    std::cmp::Ordering::Greater
-                } else {
-                    std::cmp::Ordering::Less
-                }
-            })
-            .ok()?;
-        self.nodes.get(result)
+            .partition_point(|f| f.get_range().start_byte <= offset);
+
+        // then walks backward to find the deepest one whose `end_byte >= offset`.
+        // so the first match is the most specific (deepest) node.
+        self.nodes[..idx]
+            .iter()
+            .rev()
+            .find(|f| f.get_range().end_byte >= offset)
     }
 }

--- a/examples/ast-python/src/capabilities/hover.rs
+++ b/examples/ast-python/src/capabilities/hover.rs
@@ -19,9 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 use crate::generated::{Identifier, PassStatement};
 use auto_lsp::core::ast::AstNode;
 use auto_lsp::core::dispatch_once;
+use auto_lsp::default::db::BaseDatabase;
 use auto_lsp::default::db::file::File;
 use auto_lsp::default::db::tracked::get_ast;
-use auto_lsp::default::db::BaseDatabase;
 use auto_lsp::lsp_types::{Hover, HoverParams};
 use auto_lsp::{anyhow, lsp_types};
 
@@ -32,18 +32,9 @@ pub fn hover(db: &impl BaseDatabase, params: HoverParams) -> anyhow::Result<Opti
         .get_file(uri)
         .ok_or_else(|| anyhow::format_err!("File not found in workspace"))?;
 
-    let document = file.document(db);
+    let position = params.text_document_position_params.position;
 
-    let position = document
-        .offset_at(params.text_document_position_params.position)
-        .map_err(|e| {
-            anyhow::format_err!(
-                "Invalid position, {:?}: {e}",
-                params.text_document_position_params.position
-            )
-        })?;
-
-    if let Some(node) = get_ast(db, file).descendant_at(position) {
+    if let Some(node) = get_ast(db, file).descendant_for_position(file.document(db), &position) {
         dispatch_once!(node.lower(), [
             PassStatement => get_hover(db, file),
             Identifier => get_hover(db, file)

--- a/examples/ast-python/src/capabilities/selection_ranges.rs
+++ b/examples/ast-python/src/capabilities/selection_ranges.rs
@@ -41,12 +41,16 @@ pub fn selection_ranges(
 
     for position in params.positions.iter() {
         let mut stack: Vec<tree_sitter::Node> = vec![];
-        let offset = document.offset_at(*position).unwrap();
+        let position = document.normalize_position(position).unwrap();
+        let point = tree_sitter::Point {
+            row: position.line as usize,
+            column: position.character as usize,
+        };
 
         let mut node = root_node;
         loop {
             let child = node.named_children(&mut query_cursor).find(|candidate| {
-                candidate.start_byte() <= offset && candidate.end_byte() > offset
+                candidate.start_position() <= point && candidate.end_position() > point
             });
 
             if let Some(child) = child {
@@ -58,11 +62,8 @@ pub fn selection_ranges(
         }
 
         let mut parent: Option<SelectionRange> = None;
-        for _node in stack {
-            let Some(node) = root_node.named_descendant_for_byte_range(offset, offset) else {
-                continue;
-            };
-            let Ok(range) = document.ts_range_to_range(&node.range()) else {
+        for node in stack {
+            let Ok(range) = document.denormalize_range(&node.range()) else {
                 continue;
             };
             let range = SelectionRange {

--- a/examples/ast-python/src/tests/capabilities/iter.rs
+++ b/examples/ast-python/src/tests/capabilities/iter.rs
@@ -17,8 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 use crate::db::create_python_db;
 use crate::generated::{CompoundStatement_SimpleStatement, PassStatement, SimpleStatement};
-use auto_lsp::default::db::tracked::get_ast;
 use auto_lsp::default::db::BaseDatabase;
+use auto_lsp::default::db::tracked::get_ast;
 use auto_lsp::lsp_types::Url;
 use rstest::{fixture, rstest};
 
@@ -145,4 +145,57 @@ fn parents(foo_bar: impl BaseDatabase) {
 
     // Parent id should be inferior to the child id
     assert!(pass_statement.get_id() > pass_statement_parent.get_id());
+}
+
+/// Regression test for https://github.com/adclz/auto-lsp/issues/39
+///
+/// When an offset falls between two siblings but still within their parent,
+/// the old binary search would miss the parent node due to broken monotonicity.
+#[rstest]
+fn descendant_at_between_siblings(foo_bar: impl BaseDatabase) {
+    let file = foo_bar
+        .get_file(&Url::parse("file:///test0.py").unwrap())
+        .unwrap();
+    let document = file.document(&foo_bar);
+    let source_code = document.as_bytes();
+    let ast = get_ast(&foo_bar, file);
+
+    // Offset 70 is the blank line between foo and bar, between two siblings
+    // but still within the Module parent. The old binary search could miss this.
+    let node = ast.descendant_at(70).unwrap();
+    let text = node.get_text(source_code).unwrap();
+    assert!(
+        text.contains("def foo") && text.contains("def bar"),
+        "Expected Module node containing both functions, got: {:?}",
+        text
+    );
+
+    // Offset 14 is at the start of "def foo", should find foo, not the comment
+    let node = ast.descendant_at(14).unwrap();
+    assert_eq!(
+        node.get_text(source_code).unwrap(),
+        "def foo(param1, param2: int, param3: int = 5):\n    pass"
+    );
+
+    // Offset 0 is the start of the comment, should find the module
+    let node = ast.descendant_at(0).unwrap();
+    let text = node.get_text(source_code).unwrap();
+    assert!(
+        text.contains("# foo comment"),
+        "Expected Module node at offset 0, got: {:?}",
+        text
+    );
+
+    // Last byte of the file, should still find a node
+    let last = source_code.len().saturating_sub(1);
+    assert!(
+        ast.descendant_at(last).is_some(),
+        "descendant_at should find a node at the last byte"
+    );
+
+    // Past the end, should return None
+    assert!(
+        ast.descendant_at(source_code.len() + 100).is_none(),
+        "descendant_at should return None past the end"
+    );
 }

--- a/examples/ast-python/src/tests/capabilities/iter.rs
+++ b/examples/ast-python/src/tests/capabilities/iter.rs
@@ -19,7 +19,7 @@ use crate::db::create_python_db;
 use crate::generated::{CompoundStatement_SimpleStatement, PassStatement, SimpleStatement};
 use auto_lsp::default::db::BaseDatabase;
 use auto_lsp::default::db::tracked::get_ast;
-use auto_lsp::lsp_types::Url;
+use auto_lsp::lsp_types::{Position, Url};
 use rstest::{fixture, rstest};
 
 #[fixture]
@@ -31,6 +31,10 @@ def foo(param1, param2: int, param3: int = 5):
 def bar():
     pass  
 "#])
+}
+
+fn position(line: u32, character: u32) -> Position {
+    Position { line, character }
 }
 
 #[rstest]
@@ -101,7 +105,10 @@ fn descendant_at(foo_bar: impl BaseDatabase) {
     let source_code = document.as_bytes();
     let ast = get_ast(&foo_bar, file);
 
-    let pass_statement = ast.descendant_at(66).unwrap();
+    // (2, 5) is inside the first `pass` ("    pass" on line 2)
+    let pass_statement = ast
+        .descendant_for_position(document, &position(2, 5))
+        .unwrap();
     assert_eq!(pass_statement.get_text(source_code).unwrap(), "pass");
 
     match pass_statement.downcast_ref::<CompoundStatement_SimpleStatement>() {
@@ -111,7 +118,10 @@ fn descendant_at(foo_bar: impl BaseDatabase) {
         _ => panic!("Expected PassStatement"),
     }
 
-    let pass_statement = ast.descendant_at(88).unwrap();
+    // (5, 6) is inside the second `pass` ("    pass  " on line 5)
+    let pass_statement = ast
+        .descendant_for_position(document, &position(5, 6))
+        .unwrap();
     match pass_statement.downcast_ref::<CompoundStatement_SimpleStatement>() {
         Some(CompoundStatement_SimpleStatement::SimpleStatement(
             SimpleStatement::PassStatement(PassStatement { .. }),
@@ -127,6 +137,7 @@ fn parents(foo_bar: impl BaseDatabase) {
     let file = foo_bar
         .get_file(&Url::parse("file:///test0.py").unwrap())
         .unwrap();
+    let document = file.document(&foo_bar);
     let ast = get_ast(&foo_bar, file);
 
     // The root node should have no parent
@@ -137,7 +148,10 @@ fn parents(foo_bar: impl BaseDatabase) {
         assert!(node.get_parent(ast).is_some());
     }
 
-    let pass_statement = ast.descendant_at(88).unwrap();
+    // (5, 6) is inside the second `pass`
+    let pass_statement = ast
+        .descendant_for_position(document, &position(5, 6))
+        .unwrap();
     let pass_statement_parent = pass_statement.get_parent(ast).unwrap();
 
     // Parent id should be different from the child id
@@ -160,9 +174,11 @@ fn descendant_at_between_siblings(foo_bar: impl BaseDatabase) {
     let source_code = document.as_bytes();
     let ast = get_ast(&foo_bar, file);
 
-    // Offset 70 is the blank line between foo and bar, between two siblings
-    // but still within the Module parent. The old binary search could miss this.
-    let node = ast.descendant_at(70).unwrap();
+    // (3, 0) is the blank line between foo and bar, between two siblings but still
+    // within the Module parent. The old binary search could miss this.
+    let node = ast
+        .descendant_for_position(document, &position(3, 0))
+        .unwrap();
     let text = node.get_text(source_code).unwrap();
     assert!(
         text.contains("def foo") && text.contains("def bar"),
@@ -170,15 +186,19 @@ fn descendant_at_between_siblings(foo_bar: impl BaseDatabase) {
         text
     );
 
-    // Offset 14 is at the start of "def foo", should find foo, not the comment
-    let node = ast.descendant_at(14).unwrap();
+    // (1, 0) is the start of "def foo", should find foo, not the comment
+    let node = ast
+        .descendant_for_position(document, &position(1, 0))
+        .unwrap();
     assert_eq!(
         node.get_text(source_code).unwrap(),
         "def foo(param1, param2: int, param3: int = 5):\n    pass"
     );
 
-    // Offset 0 is the start of the comment, should find the module
-    let node = ast.descendant_at(0).unwrap();
+    // (0, 0) is the start of the comment, should find the module
+    let node = ast
+        .descendant_for_position(document, &position(0, 0))
+        .unwrap();
     let text = node.get_text(source_code).unwrap();
     assert!(
         text.contains("# foo comment"),
@@ -186,16 +206,17 @@ fn descendant_at_between_siblings(foo_bar: impl BaseDatabase) {
         text
     );
 
-    // Last byte of the file, should still find a node
-    let last = source_code.len().saturating_sub(1);
+    // Last line of the file, should still find a node
     assert!(
-        ast.descendant_at(last).is_some(),
-        "descendant_at should find a node at the last byte"
+        ast.descendant_for_position(document, &position(5, 6))
+            .is_some(),
+        "descendant_at should find a node on the last line"
     );
 
-    // Past the end, should return None
+    // Past the end (line out of bounds), should return None
     assert!(
-        ast.descendant_at(source_code.len() + 100).is_none(),
+        ast.descendant_for_position(document, &position(100, 0))
+            .is_none(),
         "descendant_at should return None past the end"
     );
 }


### PR DESCRIPTION
Related to #39 

Uses [partition_point](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.partition_point) to fix the behavior of `descendant_at`.
All tests are passing but it's worth adding test cases for the edge cases where the initial issue is triggered.