### PR TITLE
Drop unnecessary notification handler

### DIFF
--- a/examples/native/src/main.rs
+++ b/examples/native/src/main.rs
@@ -27,7 +27,7 @@ use auto_lsp::lsp_server::{self, Connection};
 use auto_lsp::lsp_types::ServerCapabilities;
 use auto_lsp::lsp_types::notification::{
     Cancel, DidChangeTextDocument, DidChangeWatchedFiles, DidCloseTextDocument,
-    DidOpenTextDocument, DidSaveTextDocument, LogTrace, SetTrace,
+    DidOpenTextDocument, DidSaveTextDocument, SetTrace,
 };
 use auto_lsp::lsp_types::{self};
 use auto_lsp::server::Session;
@@ -129,5 +129,4 @@ fn on_notifications<Db: BaseDatabase + Clone + RefUnwindSafe>(
         .on::<DidSaveTextDocument, _>(ThreadIntent::Worker, |_s, _p| Ok(()))
         .on::<DidCloseTextDocument, _>(ThreadIntent::Worker, |_s, _p| Ok(()))
         .on::<SetTrace, _>(ThreadIntent::Worker, |_s, _p| Ok(()))
-        .on::<LogTrace, _>(ThreadIntent::Worker, |_s, _p| Ok(()))
 }

--- a/examples/vscode-native/server/src/main.rs
+++ b/examples/vscode-native/server/src/main.rs
@@ -42,7 +42,7 @@ use auto_lsp::default::server::workspace_init::WorkspaceInit;
 use auto_lsp::lsp_server::{self, Connection};
 use auto_lsp::lsp_types::notification::{
     Cancel, DidChangeTextDocument, DidChangeWatchedFiles, DidCloseTextDocument,
-    DidOpenTextDocument, DidSaveTextDocument, LogTrace, SetTrace,
+    DidOpenTextDocument, DidSaveTextDocument, SetTrace,
 };
 use auto_lsp::lsp_types::request::{
     CodeActionRequest, CodeLensRequest, Completion, DocumentDiagnosticRequest,
@@ -188,5 +188,4 @@ fn on_notifications<Db: BaseDatabase + Clone + RefUnwindSafe>(
         .on::<DidSaveTextDocument, _>(ThreadIntent::Worker, |_s, _p| Ok(()))
         .on::<DidCloseTextDocument, _>(ThreadIntent::Worker, |_s, _p| Ok(()))
         .on::<SetTrace, _>(ThreadIntent::Worker, |_s, _p| Ok(()))
-        .on::<LogTrace, _>(ThreadIntent::Worker, |_s, _p| Ok(()))
 }


### PR DESCRIPTION
`$/logTrace` is meant to be pushed by the server and should never be received.