### PR TITLE
Add log targets

### DIFF
--- a/crates/default/src/db/file.rs
+++ b/crates/default/src/db/file.rs
@@ -152,7 +152,7 @@ impl File {
         let (_file, buffer) = Self::read_file_content(&file_path).map_err(RuntimeError::from)?;
 
         if self.fail_fast_check(&session.db, &buffer) {
-            log::info!("File unchanged: {}", url);
+            log::info!(target: "auto_lsp::default::db", "File unchanged: {}", url);
             return Ok(());
         }
 

--- a/crates/default/src/server/file_events.rs
+++ b/crates/default/src/server/file_events.rs
@@ -45,7 +45,7 @@ pub fn open_text_document<Db: BaseDatabase>(
 
     match session.db.get_file(url) {
         Some(file) => {
-            log::info!("Did Open Text Document: Already exists - {url}");
+            log::info!(target: "auto_lsp::default::file_events", "Did Open Text Document: Already exists - {url}");
             file.set_version(&mut session.db)
                 .to(Some(params.text_document.version));
             Ok(())
@@ -57,7 +57,7 @@ pub fn open_text_document<Db: BaseDatabase>(
                 .parser(parser)
                 .call()?;
 
-            log::info!("Did Open Text Document: Created - {url}");
+            log::info!(target: "auto_lsp::default::file_events", "Did Open Text Document: Created - {url}");
             session.db.add_file(file).map_err(|e| e.into())
         }
     }
@@ -75,7 +75,7 @@ pub fn change_text_document<Db: BaseDatabase>(
             uri: params.text_document.uri.clone(),
         })?;
 
-    log::info!("Did Change Text Document: {}", params.text_document.uri);
+    log::info!(target: "auto_lsp::default::file_events", "Did Change Text Document: {}", params.text_document.uri);
     Ok(file.update_edit(&mut session.db, &params)?)
 }
 
@@ -104,7 +104,7 @@ pub fn changed_watched_files<Db: BaseDatabase, F: Fn(&Url) -> Option<&'static Pa
                         .parser(parser)
                         .call()?;
 
-                    log::info!("Watched Files: Created - {url}");
+                    log::info!(target: "auto_lsp::default::file_events", "Watched Files: Created - {url}");
                     session.db.add_file(file).map_err(RuntimeError::from)?;
                 }
                 Ok(())
@@ -118,7 +118,7 @@ pub fn changed_watched_files<Db: BaseDatabase, F: Fn(&Url) -> Option<&'static Pa
                 if let Some(parser) = get_parser(url) {
                     file.update_full_fs(session, parser)
                         .map_err(RuntimeError::from)?;
-                    log::info!("Watched Files: Changed - {url}");
+                    log::info!(target: "auto_lsp::default::file_events", "Watched Files: Changed - {url}");
                 }
                 Ok(())
             }
@@ -132,7 +132,7 @@ pub fn changed_watched_files<Db: BaseDatabase, F: Fn(&Url) -> Option<&'static Pa
                 let file = session.db.get_file(&url).unwrap();
                 file.reset(&mut session.db).map_err(RuntimeError::from)?;
 
-                log::info!("Watched Files: Deleted - {}", &url);
+                log::info!(target: "auto_lsp::default::file_events", "Watched Files: Deleted - {}", &url);
                 session.db.remove_file(&url).map_err(RuntimeError::from)
             }
             // Should never happen

--- a/crates/server/src/init.rs
+++ b/crates/server/src/init.rs
@@ -33,7 +33,7 @@ impl<Db: salsa::Database> Session<Db> {
             .unwrap_or_else(|_| NonZeroUsize::new(1).unwrap())
             .get();
 
-        log::info!("Max threads: {max_threads}");
+        log::info!(target: "auto_lsp::server::init", "Max threads: {max_threads}");
 
         let encoding = init_options
             .capabilities
@@ -41,7 +41,7 @@ impl<Db: salsa::Database> Session<Db> {
             .clone()
             .unwrap_or(PositionEncodingKind::UTF16);
 
-        log::info!("Position encoding: {encoding:?}");
+        log::info!(target: "auto_lsp::server::init", "Position encoding: {encoding:?}");
 
         Self {
             init_options,
@@ -69,8 +69,7 @@ impl<Db: salsa::Database> Session<Db> {
         #[cfg(target_arch = "wasm32")]
         std::fs::metadata("/workspace").unwrap();
 
-        log::info!("Starting LSP server");
-        log::info!("");
+        log::info!(target: "auto_lsp::server::init", "Starting LSP server");
 
         // Create the transport. Includes the stdio (stdin and stdout) versions but this could
         // also be implemented to use sockets or HTTP.

--- a/crates/server/src/notification_registry.rs
+++ b/crates/server/src/notification_registry.rs
@@ -112,7 +112,7 @@ impl<Db: salsa::Database + Clone + Send + RefUnwindSafe> NotificationRegistry<Db
             intent,
             std::panic::AssertUnwindSafe(move || {
                 match salsa::Cancelled::catch(|| cb(&db, params)) {
-                    Err(e) => log::warn!("Cancelled notification: {e}"),
+                    Err(e) => log::warn!(target: "auto_lsp::server::notification_registry", "Cancelled notification: {e}"),
                     Ok(result) => {
                         if let Err(e) = result {
                             if let Some(on_error) = on_error {

--- a/crates/server/src/request_registry.rs
+++ b/crates/server/src/request_registry.rs
@@ -117,7 +117,7 @@ impl<Db: salsa::Database + Clone + Send + RefUnwindSafe> RequestRegistry<Db> {
                 let cb = cb.clone();
                 match salsa::Cancelled::catch(|| cb(&db, params)) {
                     Err(e) => {
-                        log::warn!("Cancelled request: {e}");
+                        log::warn!(target: "auto_lsp::server::request_registry", "Cancelled request: {e}");
                     }
                     Ok(result) => match result {
                         Ok(result) => sender


### PR DESCRIPTION
I noticed that the example log filter isn't working since the messages will be tagged with a crate name such as `auto_lsp_default` (and not `auto_lsp`), so the idea is to introduce an explicit hierarchical `target`.

https://github.com/adclz/auto-lsp/blob/0ad4201b238448b14c4ddd0f6e09608c8caf7c62/examples/vscode-native/server/src/main.rs#L70